### PR TITLE
Add missing pam module to dependencies

### DIFF
--- a/core-armhf
+++ b/core-armhf
@@ -50,6 +50,7 @@ libgrilo-0.2-1
 libgrilo-0.2-bin
 liblockfile-bin
 libnss-myhostname
+libpam-fprintd
 libpam-runtime
 libpam-systemd
 libpulse-mainloop-glib0

--- a/core-i386
+++ b/core-i386
@@ -50,6 +50,7 @@ libgrilo-0.2-1
 libgrilo-0.2-bin
 liblockfile-bin
 libnss-myhostname
+libpam-fprintd
 libpam-runtime
 libpam-systemd
 libpulse-mainloop-glib0


### PR DESCRIPTION
[endlessm/eos-shell#1828]
