### PR TITLE
Add more Xorg drivers for x86

### DIFF
--- a/core-i386
+++ b/core-i386
@@ -109,6 +109,10 @@ xkb-data-i18n
 xserver-xorg
 xserver-xorg-input-evdev
 xserver-xorg-input-synaptics
+xserver-xorg-video-ati
 xserver-xorg-video-intel
+xserver-xorg-video-modesetting
+xserver-xorg-video-nouveau
 xserver-xorg-video-vesa
+xserver-xorg-video-vmware
 xterm


### PR DESCRIPTION
With ati, intel and nouveau, we cover the vast majority of hardware
cases. vmware allows more resolutions and better performance in a VMWare
vm. Finally, modesetting is like vesa for the KMS world. Any time a new
KMS device shows up in the kernel, modesetting provides a generic
interface to use it from X. In the worst case, X will fail to start if a
KMS driver is loaded and there's no KMS capable X driver.

[endlessm/eos-shell#2220]
