### PR TITLE
Install the radeon Xorg driver, not the ati metapackage

### DIFF
--- a/core-i386
+++ b/core-i386
@@ -109,10 +109,10 @@ xkb-data-i18n
 xserver-xorg
 xserver-xorg-input-evdev
 xserver-xorg-input-synaptics
-xserver-xorg-video-ati
 xserver-xorg-video-intel
 xserver-xorg-video-modesetting
 xserver-xorg-video-nouveau
+xserver-xorg-video-radeon
 xserver-xorg-video-vesa
 xserver-xorg-video-vmware
 xterm


### PR DESCRIPTION
xserver-xorg-video-ati is actually a metapackage that also requires the
mach64 and r128 drivers. Not only do we not have those drivers, but
they're only needed for ancient hardware. The driver we really want that
covers any ATI hardware from the past 10ish years is the radeon driver
included in the xserver-xorg-video-ati source package.

[endlessm/eos-shell#2220]
