### PR TITLE
Add libhal1-flash for x86 flash DRM content

### DIFF
--- a/core-i386
+++ b/core-i386
@@ -54,6 +54,7 @@ libfolks-telepathy25
 libglib2.0-data
 libgrilo-0.2-1
 libgrilo-0.2-bin
+libhal1-flash
 liblockfile-bin
 libnss-altfiles
 libnss-myhostname


### PR DESCRIPTION
In order to play DRM flash content such as Amazon videos, the flash
DRM capabilities need to be enabled. The hal-flash library does this
by providing the needed symbols from libhal1 and using udisks2 to
query for information.

This is only enabled on i386 as we have currently have no way to
enable flash on ARM.

[endlessm/eos-shell#556]
