### PR TITLE
Add core dependency on eos-wikipedia

### DIFF
--- a/apps-armhf
+++ b/apps-armhf
@@ -10,7 +10,6 @@ eos-programming
 eos-resume
 eos-translation
 eos-typing
-eos-wikipedia
 eos-youtube
 eos-weather
 four-in-a-row

--- a/apps-i386
+++ b/apps-i386
@@ -14,7 +14,6 @@ eos-programming
 eos-resume
 eos-translation
 eos-typing
-eos-wikipedia
 eos-youtube
 eos-weather
 extremetuxracer

--- a/core-armhf
+++ b/core-armhf
@@ -32,6 +32,7 @@ eos-social
 eos-tech-support
 eos-theme
 eos-updater
+eos-wikipedia
 epiphany-browser
 evolution
 evolution-data-server

--- a/core-i386
+++ b/core-i386
@@ -32,6 +32,7 @@ eos-social
 eos-tech-support
 eos-theme
 eos-updater
+eos-wikipedia
 epiphany-browser
 evolution
 evolution-data-server


### PR DESCRIPTION
The shell includes wikipedia search right from the desktop, think
this package makes sense to stick in core (similar to social bar)
so it will always be installed on a user machine
[endlessm/eos-sdk#1300]
