### PR TITLE
Add mobile-broadband-provider-info to core

### DIFF
--- a/core-armhf
+++ b/core-armhf
@@ -124,6 +124,7 @@ lsb-base
 lsb-release
 lzma
 mawk
+mobile-broadband-provider-info
 module-init-tools
 net-tools
 netbase

--- a/core-i386
+++ b/core-i386
@@ -125,6 +125,7 @@ lsb-base
 lsb-release
 lzma
 mawk
+mobile-broadband-provider-info
 module-init-tools
 net-tools
 netbase


### PR DESCRIPTION
Required to support 3G dongles.

[endlessm/eos-shell#2759]
