### PR TITLE
Remove epiphany browser from eos-core

### DIFF
--- a/core-armhf
+++ b/core-armhf
@@ -34,7 +34,6 @@ eos-tech-support
 eos-theme
 eos-updater
 eos-wikipedia
-epiphany-browser
 evolution
 exfat-fuse
 file

--- a/core-i386
+++ b/core-i386
@@ -34,7 +34,6 @@ eos-tech-support
 eos-theme
 eos-updater
 eos-wikipedia
-epiphany-browser
 evolution
 exfat-fuse
 file


### PR DESCRIPTION
Previously was left for testing/evaluation, but no longer relevant.
For users, we only support chromium.

[endlessm/eos-shell#2771]
