### PR TITLE
Updated core and apps lists for rebrand of app names

### DIFF
--- a/apps-armhf
+++ b/apps-armhf
@@ -10,8 +10,8 @@ eos-programming
 eos-resume
 eos-translation
 eos-typing
-eos-youvideos
 eos-weather
+eos-youvideos
 four-in-a-row
 freeciv-client-gtk
 frostwire

--- a/apps-i386
+++ b/apps-i386
@@ -14,8 +14,8 @@ eos-programming
 eos-resume
 eos-translation
 eos-typing
-eos-youvideos
 eos-weather
+eos-youvideos
 extremetuxracer
 four-in-a-row
 freeciv-client-gtk

--- a/core-armhf
+++ b/core-armhf
@@ -18,6 +18,7 @@ empathy
 eog
 eos-app-manager
 eos-boot-helper
+eos-encyclopedia
 eos-exploration-center
 eos-file-manager
 eos-keyring
@@ -33,7 +34,6 @@ eos-social
 eos-tech-support
 eos-theme
 eos-updater
-eos-encyclopedia
 evolution
 exfat-fuse
 file

--- a/core-i386
+++ b/core-i386
@@ -18,6 +18,7 @@ empathy
 eog
 eos-app-manager
 eos-boot-helper
+eos-encyclopedia
 eos-exploration-center
 eos-file-manager
 eos-flashplugin-updater
@@ -34,7 +35,6 @@ eos-social
 eos-tech-support
 eos-theme
 eos-updater
-eos-encyclopedia
 evolution
 exfat-fuse
 file


### PR DESCRIPTION
eos-youtube has become eos-youvideos and eos-wikipedia has become
eos-encyclopedia
[endlessm/eos-sdk#1300]
