### PR TITLE
Remove stellarium-wrapper from eos-apps

### DIFF
--- a/debian/eos-apps.install
+++ b/debian/eos-apps.install
@@ -1,2 +1,0 @@
-stellarium-wrapper/stellarium-wrapper usr/bin
-stellarium-wrapper/default-configs usr/share/stellarium


### PR DESCRIPTION
This has been moved to the stellarium debian package to support building
into the app bundle.

[endlessm/eos-shell#2648]
