### PR TITLE
Add boost libraries needed for apps to core

### DIFF
--- a/core-armhf
+++ b/core-armhf
@@ -82,6 +82,12 @@ libalut0
 libasound2
 libatkmm-1.6-1
 libbluetooth3
+libboost-iostreams1.49.0
+libboost-program-options1.49.0
+libboost-python1.49.0
+libboost-regex1.49.0
+libboost-signals1.49.0
+libboost-system1.49.0
 libcairomm-1.0-1
 libcanberra-gtk-module
 libcanberra-pulse

--- a/core-i386
+++ b/core-i386
@@ -83,6 +83,12 @@ libalut0
 libasound2
 libatkmm-1.6-1
 libbluetooth3
+libboost-iostreams1.49.0
+libboost-program-options1.49.0
+libboost-python1.49.0
+libboost-regex1.49.0
+libboost-signals1.49.0
+libboost-system1.49.0
 libcairomm-1.0-1
 libcanberra-gtk-module
 libcanberra-pulse


### PR DESCRIPTION
A few apps have dependencies on the boost libraries:

  kalzium - libboost-python1.49.0
  pingus - libboost-signals1.49.0
  wesnoth-1.11 - libboost-iostreams1.49.0 libboost-program-options1.49.0
                 libboost-regex1.49.0 libboost-system1.49.0

Ideally we would bundle the needed boost libraries with each app, but
boost is a really large source package and it would be a significant
amount of work to bundle it 3 times. Just add it to the core as the
individual packages are actually quite small.

[endlessm/eos-shell#2968]
