### PR TITLE
Allow all non-metrics-related code to execute.

### DIFF
--- a/eos-tech-support/eos-convert-system
+++ b/eos-tech-support/eos-convert-system
@@ -7,7 +7,7 @@ fi
 
 # Set the metrics system to use the dev environment
 echo "Configuring Metrics System for Dev"
-exec eos-select-metrics-env 'dev'
+source eos-select-metrics-env 'dev'
 
 # Disable upgrade timer
 systemctl stop eos-updater.timer


### PR DESCRIPTION
exec replaces the current process with a new one, which is not what we
want. source runs another script and then continues with the current
process, which is what we want.

[endlessm/eos-sdk#1576]
