### PR TITLE
Update home folder

### DIFF
--- a/eos-tech-support/eos-convert-system
+++ b/eos-tech-support/eos-convert-system
@@ -65,6 +65,9 @@ find /sysroot/{bin,etc,lib,sbin,usr,var} -xdev -type f -size 0 -links +2 \
 mkdir /sysroot/sysroot
 ln -s /home /sysroot/sysroot/
 
+# As now the real homedir is /home and not /sysroot/home, update passwd accordingly
+sed -i "s#/sysroot/home#/home#g" /etc/passwd*
+
 if [ -L /boot/uEnv.txt ] ; then 
   # Running on ARM
   echo "Please install flash-kernel after reboot for correct kernel upgrades" 


### PR DESCRIPTION
When converting a system, we move /sysroot/home to /home. So let's
update /etc/passwd too.

[endlessm/eos-shell#2827]
