### PR TITLE
Update $HOME in converted system properly

### DIFF
--- a/eos-tech-support/eos-convert-system
+++ b/eos-tech-support/eos-convert-system
@@ -39,6 +39,10 @@ else
   exit 1
 fi
 
+# As now the real homedir will be /home and not /sysroot/home, update passwd accordingly
+echo "Updating HOME directory"
+sed -i "s#/sysroot/home#/home#g" /etc/passwd* /etc/adduser.conf /etc/default/useradd
+
 echo "Hardlinking files from $OSTREE_DEPLOY_CURRENT, this may take a while"
 
 # Copy the system directories to the real filesystems /
@@ -64,9 +68,6 @@ find /sysroot/{bin,etc,lib,sbin,usr,var} -xdev -type f -size 0 -links +2 \
 # pick that up when re-generating the initramfs and blow up
 mkdir /sysroot/sysroot
 ln -s /home /sysroot/sysroot/
-
-# As now the real homedir is /home and not /sysroot/home, update passwd accordingly
-sed -i "s#/sysroot/home#/home#g" /etc/passwd*
 
 if [ -L /boot/uEnv.txt ] ; then 
   # Running on ARM


### PR DESCRIPTION
This is a fix over 0d1b7e93f8.

We need to do the replacement at the very beginning, otherwise after
rebooting we will loose them.

Also, we need to update a couple of files more.

[endlessm/eos-shell#2827]
