### PR TITLE
Include liblua in core for games

### DIFF
--- a/core-armhf
+++ b/core-armhf
@@ -110,6 +110,8 @@ libkdegamesprivate1abi1
 libkeduvocdocument4
 libkprintutils4
 liblockfile-bin
+liblua5.1-0
+liblua5.2-0
 libnss-altfiles
 libnss-myhostname
 libpam-fprintd

--- a/core-i386
+++ b/core-i386
@@ -112,6 +112,8 @@ libkdegamesprivate1abi1
 libkeduvocdocument4
 libkprintutils4
 liblockfile-bin
+liblua5.1-0
+liblua5.2-0
 libnss-altfiles
 libnss-myhostname
 libpam-fprintd


### PR DESCRIPTION
Many games use lua to provide a scripting interface, so it's beneficial
to have it in the core. Each library is only around 100 kB.

[endlessm/eos-shell#3095]
