### PR TITLE
Include console-setup-mini as part of core

### DIFF
--- a/core-armhf
+++ b/core-armhf
@@ -10,6 +10,7 @@ bzip2
 ca-certificates
 cheese
 chromium-browser
+console-setup-mini
 cups
 dbus-x11
 debconf-i18n

--- a/core-i386
+++ b/core-i386
@@ -10,6 +10,7 @@ bzip2
 ca-certificates
 cheese
 chromium-browser
+console-setup-mini
 cups
 dbus-x11
 debconf-i18n


### PR DESCRIPTION
Required if we want to change keyboard layout in command-line console.

[endlessm/eos-shell#3568]
