### PR TITLE
core: Add khelpcenter4

### DIFF
--- a/core-armhf
+++ b/core-armhf
@@ -92,6 +92,7 @@ iproute
 kde-games-core-declarative
 kde-runtime
 kdeedu-kvtml-data
+khelpcenter4
 less
 libalut0
 libasound2

--- a/core-i386
+++ b/core-i386
@@ -93,6 +93,7 @@ iproute
 kde-games-core-declarative
 kde-runtime
 kdeedu-kvtml-data
+khelpcenter4
 less
 libalut0
 libasound2


### PR DESCRIPTION
Many KDE apps use khelpcenter to handle documentation, but it is not a
depedency of anything in the core. Add it here.

[endlessm/eos-shell#3011]
