### PR TITLE
eos-convert-system: Rename initramfs file to initrd.img-<kernel-version>

### DIFF
--- a/eos-tech-support/eos-convert-system
+++ b/eos-tech-support/eos-convert-system
@@ -83,7 +83,7 @@ if [ -L /boot/uEnv.txt ] ; then
 else
   # Intel, put the kernels/initramfs in the expected place by Debian
   cp -pax ${OSTREE_DEPLOY_CURRENT}/boot/{vmlinuz,initramfs}*  /boot
-  rename 's/-\w*$//g,s/initramfs/initrd/g' /boot/{vmlinuz,init}*
+  rename 's/-\w*$//g,s/initramfs/initrd\.img/g' /boot/{vmlinuz,init}*
 
   O=$(grep options /boot/loader/entries/*.conf | head -n1 | cut -d ' ' -f 2-)
   echo GRUB_CMDLINE_LINUX_DEFAULT=\"${O} \" | sed 's/ostree=[^ ]*//g' \


### PR DESCRIPTION
We need to do this because that's the name that will be expected when
updating or re-creating the initramfs file update-initramfs, since
that's the named pointed from /var/lib/initramfs-tools/<kernel-version>

[endlessm/eos-shell#3723]
