### PR TITLE
Add aspell dictionaries

### DIFF
--- a/language-pack-ar-all
+++ b/language-pack-ar-all
@@ -1,3 +1,4 @@
+aspell-ar
 hunspell-ar
 kde-l10n-ar
 libreoffice-l10n-ar

--- a/language-pack-es-all
+++ b/language-pack-es-all
@@ -1,3 +1,4 @@
+aspell-es
 kde-l10n-es
 libreoffice-help-es
 libreoffice-l10n-es

--- a/language-pack-fr-all
+++ b/language-pack-fr-all
@@ -1,3 +1,4 @@
+aspell-fr
 hunspell-fr
 kde-l10n-fr
 libreoffice-help-fr

--- a/language-pack-pt-all
+++ b/language-pack-pt-all
@@ -1,3 +1,5 @@
+aspell-pt-br
+aspell-pt-pt
 kde-l10n-pt
 kde-l10n-ptbr
 libreoffice-help-pt


### PR DESCRIPTION
Explicitly specify dependencies for ar, es, fr, and pt.

Note that aspell-en is already implicitly included
as a recommended dependency of aspell.

[endlessm/eos-shell#3353]
