### PR TITLE
core: Add fonts-droid

### DIFF
--- a/core-armhf
+++ b/core-armhf
@@ -51,6 +51,7 @@ fonts-arphic-uming
 fonts-crosextra-caladea
 fonts-crosextra-carlito
 fonts-dosis
+fonts-droid
 fonts-dustin
 fonts-farsiweb
 fonts-gargi

--- a/core-i386
+++ b/core-i386
@@ -53,6 +53,7 @@ fonts-arphic-uming
 fonts-crosextra-caladea
 fonts-crosextra-carlito
 fonts-dosis
+fonts-droid
 fonts-dustin
 fonts-farsiweb
 fonts-gargi


### PR DESCRIPTION
This is wanted by wesnoth, but it was also available in eos1 and is
generally a nice font to have. See http://www.droidfonts.com/.

[endlessm/eos-shell#3190]
