### PR TITLE
Explicitly add libav/ffmeg libraries to core

### DIFF
--- a/core-armhf
+++ b/core-armhf
@@ -107,6 +107,11 @@ less
 libalut0
 libasound2
 libatkmm-1.6-1
+libavcodec53
+libavdevice53
+libavfilter2
+libavformat53
+libavutil51
 libbluetooth3
 libboost-iostreams1.49.0
 libboost-program-options1.49.0
@@ -143,6 +148,7 @@ libpam-fprintd
 libpam-runtime
 libpam-systemd
 libpangomm-1.4-1
+libpostproc52
 libpulse-mainloop-glib0
 libpulse0
 libreoffice
@@ -153,6 +159,7 @@ libsdl-net1.2
 libsdl-pango1
 libsdl-ttf2.0-0
 libsdl1.2debian
+libswscale2
 libtelepathy-farstream3
 libumfpack5.4.0
 linux-firmware

--- a/core-i386
+++ b/core-i386
@@ -109,6 +109,11 @@ less
 libalut0
 libasound2
 libatkmm-1.6-1
+libavcodec53
+libavdevice53
+libavfilter2
+libavformat53
+libavutil51
 libbluetooth3
 libboost-iostreams1.49.0
 libboost-program-options1.49.0
@@ -146,6 +151,7 @@ libpam-fprintd
 libpam-runtime
 libpam-systemd
 libpangomm-1.4-1
+libpostproc52
 libpulse-mainloop-glib0
 libpulse0
 libreoffice
@@ -156,6 +162,7 @@ libsdl-net1.2
 libsdl-pango1
 libsdl-ttf2.0-0
 libsdl1.2debian
+libswscale2
 libtelepathy-farstream3
 libumfpack5.4.0
 linux-firmware


### PR DESCRIPTION
Most of these already get pulled in via gstreamer1.0-libav (from totem),
but not libpostproc52. Instead of having a partial libav install, make
sure we have the entire library set so it can be used by bundles like
frostwire.

[endlessm/eos-shell#3218]
