### PR TITLE
core: Add python-gst-1.0

### DIFF
--- a/core-armhf
+++ b/core-armhf
@@ -186,6 +186,7 @@ printer-driver-all
 pulseaudio
 pulseaudio-module-bluetooth
 pulseaudio-module-x11
+python-gst-1.0
 rhythmbox (>= 2.99.1)
 rtkit
 shotwell

--- a/core-i386
+++ b/core-i386
@@ -189,6 +189,7 @@ printer-driver-all
 pulseaudio
 pulseaudio-module-bluetooth
 pulseaudio-module-x11
+python-gst-1.0
 rhythmbox (>= 2.99.1)
 rtkit
 shotwell


### PR DESCRIPTION
This is only used by pitivi, which is a bundle, but integrating with the
python-gi overrides from outside the system overrides directory is
incredibly difficult. This library is only 140 kB and gstreamer is most
definitely part of the core, so just include the python bindings, too.

[endlessm/eos-shell#3832]
