### PR TITLE
Add metapackages for ARM platform variants

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -20,6 +20,28 @@ Description: Target packages of the Endless distribution
  It is also used to help ensure proper upgrades, so it is recommended that
  it not be removed.
 
+Package: eos-core-odroidu2
+Architecture: armhf
+Depends: ${misc:Depends}, ${germinate:Depends}
+Description: Target packages of the Endless distribution for odroidu2
+ This package depends on all packages required for the Endless OS core images
+ .
+ It is also used to help ensure proper upgrades, so it is recommended that
+ it not be removed.
+ .
+ This set provides the platform specific package list for armhf-odroidu2.
+
+Package: eos-core-sqwerty
+Architecture: armhf
+Depends: ${misc:Depends}, ${germinate:Depends}
+Description: Target packages of the Endless distribution for sqwerty
+ This package depends on all packages required for the Endless OS core images
+ .
+ It is also used to help ensure proper upgrades, so it is recommended that
+ it not be removed.
+ .
+ This set provides the platform specific package list for armhf-sqwerty.
+
 Package: eos-apps
 Architecture: any
 Replaces: eos-shell-apps


### PR DESCRIPTION
Instead of keeping the platform specific package list for our ARM
variants in the image builder, make proper metapackages for them. This
adds eos-core-odroidu2 and eos-core-sqwerty for our 2 currently
supported ARM variants.

With these packages in place, the image builder can simply install the
platform specific eos-core package for each ARM variant and drop the
custom list of packages.

[endlessm/eos-shell#4107]
