### PR TITLE
Add libkunitconversion4 in core-i386

### DIFF
--- a/core-armhf
+++ b/core-armhf
@@ -142,6 +142,7 @@ libkdegames6abi1
 libkdegamesprivate1abi1
 libkeduvocdocument4
 libkprintutils4
+libkunitconversion4
 liblockfile-bin
 liblua5.1-0
 liblua5.2-0

--- a/core-i386
+++ b/core-i386
@@ -149,6 +149,7 @@ libkdegames6abi1
 libkdegamesprivate1abi1
 libkeduvocdocument4
 libkprintutils4
+libkunitconversion4
 liblockfile-bin
 liblua5.1-0
 liblua5.2-0


### PR DESCRIPTION
This package is part of KDE 4 libraries, and it is required by Kalzium.

[endlessm/eos-shell#3222]
