### PR TITLE
Add gstreamer-0.10 deps to core for bundles

### DIFF
--- a/core-armhf
+++ b/core-armhf
@@ -91,6 +91,8 @@ gnome-system-monitor
 gnome-terminal
 gnupg
 grilo-plugins-0.2
+gstreamer0.10-alsa
+gstreamer0.10-plugins-base
 gstreamer0.10-plugins-good
 gstreamer0.10-pulseaudio
 gstreamer1.0-plugins-good

--- a/core-i386
+++ b/core-i386
@@ -95,6 +95,8 @@ gnome-terminal
 gnupg
 grilo-plugins-0.2
 grub2
+gstreamer0.10-alsa
+gstreamer0.10-plugins-base
 gstreamer0.10-plugins-good
 gstreamer0.10-pulseaudio
 gstreamer1.0-plugins-good


### PR DESCRIPTION
When phonon was updated to gstreamer-1.0, gstreamer0.10-alsa was dropped
from the core. However, this is needed by gcompris for sound. Since many
bundles rely on gstreamer-0.10, explictly add all of these deps to the
core. For a future release, we can work on fully purging gstreamer-0.10.

[endlessm/eos-shell#4168]
