### PR TITLE
Add explicit dep on gettext-base needed for scratch bundle

### DIFF
--- a/core-armhf
+++ b/core-armhf
@@ -78,6 +78,7 @@ fprintd
 freeglut3
 gedit
 geoclue-2.0
+gettext-base
 gnome-accessibility-themes
 gnome-calculator
 gnome-clocks

--- a/core-i386
+++ b/core-i386
@@ -81,6 +81,7 @@ fprintd
 freeglut3
 gedit
 geoclue-2.0
+gettext-base
 gnome-accessibility-themes
 gnome-calculator
 gnome-clocks


### PR DESCRIPTION
The Squeak VM used by Scratch has a dependency on gettext-base to use
the gettext binary. This is included on i386 since grub pulls in
gettext-base, but it's not included on armhf. That prevents scratch from
being bundled for arm.

I'm pretty sure we could make the squeak package not use gettext since
it's only used in the wrapper script that we'll never use, but I'd
prefer to be consistent and have gettext be part of the core. This would
add 2 packages - gettext-base and its dependency libasprintf0c2.
Combined they're about 910 kB installed.

[endlessm/eos-shell#4169]
