### PR TITLE
Add metapackage for i386 "platform"

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -20,6 +20,17 @@ Description: Target packages of the Endless distribution
  It is also used to help ensure proper upgrades, so it is recommended that
  it not be removed.
 
+Package: eos-core-i386
+Architecture: i386
+Depends: ${misc:Depends}, ${germinate:Depends}
+Description: Target packages of the Endless distribution for i386
+ This package depends on all packages required for the Endless OS core images
+ .
+ It is also used to help ensure proper upgrades, so it is recommended that
+ it not be removed.
+ .
+ This set provides the platform specific package list for i386.
+
 Package: eos-core-odroidu2
 Architecture: armhf
 Depends: ${misc:Depends}, ${germinate:Depends}


### PR DESCRIPTION
Although, there are no platform specific packages for i386, we want to
create eos-core-i386 so we can simply use eos-core-$platform whenever
handling the core metapackages.

[endlessm/eos-shell#4338]
