### PR TITLE
core: Add libboost-filesystem and -thread for openscad

### DIFF
--- a/core-armhf
+++ b/core-armhf
@@ -117,12 +117,14 @@ libavfilter2
 libavformat53
 libavutil51
 libbluetooth3
+libboost-filesystem1.49.0
 libboost-iostreams1.49.0
 libboost-program-options1.49.0
 libboost-python1.49.0
 libboost-regex1.49.0
 libboost-signals1.49.0
 libboost-system1.49.0
+libboost-thread1.49.0
 libcairomm-1.0-1
 libcanberra-gtk-module
 libcanberra-pulse

--- a/core-i386
+++ b/core-i386
@@ -121,12 +121,14 @@ libavfilter2
 libavformat53
 libavutil51
 libbluetooth3
+libboost-filesystem1.49.0
 libboost-iostreams1.49.0
 libboost-program-options1.49.0
 libboost-python1.49.0
 libboost-regex1.49.0
 libboost-signals1.49.0
 libboost-system1.49.0
+libboost-thread1.49.0
 libcairomm-1.0-1
 libcanberra-gtk-module
 libcanberra-pulse


### PR DESCRIPTION
These are small packages, 67 kB and 52 kB, respectively. Add them with
the other boost libraries in the core.

[endlessm/eos-shell#4287]
