### PR TITLE
Replace system-config-printer with system-config-printer-gnome

### DIFF
--- a/core-armhf
+++ b/core-armhf
@@ -201,7 +201,7 @@ rtkit
 shotwell
 singularity-archive-keyring
 sudo
-system-config-printer
+system-config-printer-gnome
 systemd-sysv
 telepathy-gabble
 telepathy-mission-control-5

--- a/core-i386
+++ b/core-i386
@@ -209,7 +209,7 @@ rtkit
 shotwell
 singularity-archive-keyring
 sudo
-system-config-printer
+system-config-printer-gnome
 systemd-sysv
 telepathy-gabble
 telepathy-mission-control-5


### PR DESCRIPTION
With the upgrade from s-c-p 1.4.3 to 1.5.4, the packages that are being
installed changed and the old system-config-printer packages has been
split into system-config-printer-gnome and system-config-printer-common,
so we need to update de depenency in eos-core to reflect that.

[endlessm/eos-shell#4445]
