### PR TITLE
Remove pbuilder from list of eos-dev dependencies.

### DIFF
--- a/dev-all
+++ b/dev-all
@@ -49,7 +49,6 @@ openssh-server
 osc
 p7zip-full
 patchutils
-pbuilder
 pep8
 putty
 pyflakes


### PR DESCRIPTION
pbuilder has a bug in its Debian packaging that causes it to prompt the
user for a mirror when /etc/apt/sources.list uses https. The prompt is
confusing, so let's narrow the scope of developers who have to deal with
this quirk to just those who actually need pbuilder.

[endlessm/eos-shell#4753]
