### PR TITLE
Include libwpd and libwpg in core

### DIFF
--- a/core-armhf
+++ b/core-armhf
@@ -173,8 +173,10 @@ libsdl1.2debian
 libswscale2
 libtelepathy-farstream3
 libumfpack5.4.0
+libwpd-0.10-10
 libwpd-0.9-9
 libwpg-0.2-2
+libwpg-0.3-3
 linux-firmware
 locales
 lsb-base

--- a/core-i386
+++ b/core-i386
@@ -181,8 +181,10 @@ libsdl1.2debian
 libswscale2
 libtelepathy-farstream3
 libumfpack5.4.0
+libwpd-0.10-10
 libwpd-0.9-9
 libwpg-0.2-2
+libwpg-0.3-3
 linux-firmware
 linux-image-generic
 locales


### PR DESCRIPTION
There are needed by inkscape, so make sure they stay in the core past any updates.

[endlessm/eos-shell#4780]
