### PR TITLE
Remove libdvdcss2 from images

### DIFF
--- a/core-armhf
+++ b/core-armhf
@@ -132,7 +132,6 @@ libcanberra-gtk-module
 libcanberra-pulse
 libcaribou-gtk-module
 libcaribou-gtk3-module
-libdvdcss2
 libfolks-eds25
 libfolks-telepathy25
 libgc1c3

--- a/core-i386
+++ b/core-i386
@@ -137,7 +137,6 @@ libcanberra-gtk-module
 libcanberra-pulse
 libcaribou-gtk-module
 libcaribou-gtk3-module
-libdvdcss2
 libegl1-mesa-drivers
 libfolks-eds25
 libfolks-telepathy25


### PR DESCRIPTION
We cannot ship this due to licensing concerns.

[endlessm/eos-shell#4825]
