### PR TITLE
Add gstreamer-tools to generate plugin registries

### DIFF
--- a/core-armhf
+++ b/core-armhf
@@ -99,9 +99,11 @@ gstreamer0.10-alsa
 gstreamer0.10-plugins-base
 gstreamer0.10-plugins-good
 gstreamer0.10-pulseaudio
+gstreamer0.10-tools
 gstreamer1.0-plugins-good
 gstreamer1.0-plugins-ugly
 gstreamer1.0-pulseaudio
+gstreamer1.0-tools
 gvfs-bin
 icedtea-plugin
 iproute

--- a/core-i386
+++ b/core-i386
@@ -104,9 +104,11 @@ gstreamer0.10-alsa
 gstreamer0.10-plugins-base
 gstreamer0.10-plugins-good
 gstreamer0.10-pulseaudio
+gstreamer0.10-tools
 gstreamer1.0-plugins-good
 gstreamer1.0-plugins-ugly
 gstreamer1.0-pulseaudio
+gstreamer1.0-tools
 gvfs-bin
 icedtea-plugin
 iproute


### PR DESCRIPTION
These will be used to create the gstreamer system plugin registries in
the image builder.

[endlessm/eos-shell#4835]
