### PR TITLE
Include openssh-server in the core by default

### DIFF
--- a/core-armhf
+++ b/core-armhf
@@ -195,6 +195,7 @@ ntp
 obexd-client
 openprinting-ppds
 openssh-client
+openssh-server
 ostree
 p7zip-full
 policykit-1

--- a/core-i386
+++ b/core-i386
@@ -204,6 +204,7 @@ ntp
 obexd-client
 openprinting-ppds
 openssh-client
+openssh-server
 ostree
 p7zip-full
 policykit-1


### PR DESCRIPTION
[endlessm/eos-shell#4824]
