### PR TITLE
modesetting driver is now part of X

### DIFF
--- a/core-i386
+++ b/core-i386
@@ -245,7 +245,6 @@ xserver-xorg
 xserver-xorg-input-evdev
 xserver-xorg-input-synaptics
 xserver-xorg-video-intel
-xserver-xorg-video-modesetting
 xserver-xorg-video-nouveau
 xserver-xorg-video-qxl
 xserver-xorg-video-radeon


### PR DESCRIPTION
The modesetting video driver is now included in the X server itself.
This package is going to be removed.

[endlessm/eos-shell#4788]
