### PR TITLE
Remove console-setup-mini

### DIFF
--- a/core-armhf
+++ b/core-armhf
@@ -10,7 +10,6 @@ bzip2
 ca-certificates
 cheese
 chromium-browser
-console-setup-mini
 cups
 dbus-x11
 debconf-i18n

--- a/core-i386
+++ b/core-i386
@@ -10,7 +10,6 @@ bzip2
 ca-certificates
 cheese
 chromium-browser
-console-setup-mini
 cups
 dbus-x11
 debconf-i18n


### PR DESCRIPTION
This isn't needed on our platform.

[endlessm/eos-shell#4725]
