### PR TITLE
Include previous boots in diagnostic journal log

### DIFF
--- a/eos-tech-support/eos-diagnostics
+++ b/eos-tech-support/eos-diagnostics
@@ -310,7 +310,7 @@ function dumpDiagnostics(filename) {
     fullDump += '= Journal output =\n';
     fullDump += '==================\n';
     fullDump += '\n';
-    fullDump += trySpawn('journalctl -b --no-pager');
+    fullDump += trySpawn('journalctl --no-pager');
 
     try {
 	GLib.file_set_contents(filename, fullDump);


### PR DESCRIPTION
By default, we only log the journal to memory,
so we only get logs for the current boot anyhow.
But in the case where the user intentionally
persists the journal logs, we should include
them in the diagnostic report.

[endlessm/eos-shell#4955]
