### PR TITLE
eos-write-image: Don't use conv=sparse + other fixes

### DIFF
--- a/eos-tech-support/eos-write-image
+++ b/eos-tech-support/eos-write-image
@@ -91,7 +91,7 @@ if [ ! -f "$IMAGE" ]; then
 fi
 
 if [ ! -b $DEVICE ]; then
-    echo "$DEVICE not found"
+    echo "$DEVICE not found or is not a block device"
     exit 1
 fi
 


### PR DESCRIPTION
Various improvements to eos-write-image. Most importantly, don't use dd's conv=sparse by default since it causes ostree fsck errors.

[endlessm/eos-shell#4949]
