### PR TITLE
Install attr

### DIFF
--- a/core-armhf
+++ b/core-armhf
@@ -3,6 +3,7 @@ alsa-utils
 apt
 apt-transport-https
 apt-utils
+attr
 avahi-daemon
 bluez
 btrfs-tools

--- a/core-i386
+++ b/core-i386
@@ -3,6 +3,7 @@ alsa-utils
 apt
 apt-transport-https
 apt-utils
+attr
 avahi-daemon
 bluez
 btrfs-tools


### PR DESCRIPTION
We're expecting the factory to use this in their factory test
scripts, to read the EOS image version xattr from the SD card.

[endlessm/eos-shell#4997]
