### PR TITLE
Update core packages to depend on new knowledge lib package

### DIFF
--- a/core-armhf
+++ b/core-armhf
@@ -20,12 +20,12 @@ empathy
 eog
 eos-app-manager
 eos-boot-helper
-eos-encyclopedia
 eos-event-recorder-daemon
 eos-exploration-center
 eos-factory-test
 eos-file-manager
 eos-keyring
+eos-knowledge-0
 eos-language-pack-ar
 eos-language-pack-en
 eos-language-pack-es

--- a/core-i386
+++ b/core-i386
@@ -20,7 +20,6 @@ empathy
 eog
 eos-app-manager
 eos-boot-helper
-eos-encyclopedia
 eos-event-recorder-daemon
 eos-exploration-center
 eos-factory-test
@@ -29,6 +28,7 @@ eos-flashplugin-updater
 eos-gates
 eos-google-talkplugin-updater
 eos-keyring
+eos-knowledge-0
 eos-language-pack-ar
 eos-language-pack-en
 eos-language-pack-es


### PR DESCRIPTION
Encyclopedia package is now deprecated, all encycopedia code has moved
into knowledge lib.
[endlessm/eos-sdk#3102]
