### PR TITLE
Install wine

### DIFF
--- a/core-i386
+++ b/core-i386
@@ -236,6 +236,7 @@ unoconv
 usb-modeswitch
 vim-tiny
 whiptail
+wine
 wpasupplicant
 xauth
 xdg-user-dirs


### PR DESCRIPTION
Even though not officially supported or integrated with our desktop,
let's make this available for advanced users to try to run Windows
applications from the command line.

Note that we do not build and install libwine-gecko at this time.

[endlessm/eos-shell#5065]
