### PR TITLE
Depend on gnome-themes-standard

### DIFF
--- a/core-armhf
+++ b/core-armhf
@@ -82,7 +82,6 @@ freeglut3
 gedit
 geoclue-2.0
 gettext-base
-gnome-accessibility-themes
 gnome-calculator
 gnome-clocks
 gnome-control-center
@@ -93,6 +92,7 @@ gnome-session
 gnome-sushi
 gnome-system-monitor
 gnome-terminal
+gnome-themes-standard
 gnupg
 grilo-plugins-0.2
 gstreamer0.10-alsa

--- a/core-i386
+++ b/core-i386
@@ -86,7 +86,6 @@ freeglut3
 gedit
 geoclue-2.0
 gettext-base
-gnome-accessibility-themes
 gnome-calculator
 gnome-clocks
 gnome-control-center
@@ -97,6 +96,7 @@ gnome-session
 gnome-sushi
 gnome-system-monitor
 gnome-terminal
+gnome-themes-standard
 gnupg
 grilo-plugins-0.2
 grub2


### PR DESCRIPTION
Instead of gnome-accessibility-themes, since we now also pick the GTK 2
theme from there.

[endlessm/eos-shell#4538]
