### PR TITLE
Don't pull gstreamer1.0-plugins-ugly into eos-core

### DIFF
--- a/core-armhf
+++ b/core-armhf
@@ -101,7 +101,6 @@ gstreamer0.10-plugins-good
 gstreamer0.10-pulseaudio
 gstreamer0.10-tools
 gstreamer1.0-plugins-good
-gstreamer1.0-plugins-ugly
 gstreamer1.0-pulseaudio
 gstreamer1.0-tools
 gvfs-bin

--- a/core-i386
+++ b/core-i386
@@ -106,7 +106,6 @@ gstreamer0.10-plugins-good
 gstreamer0.10-pulseaudio
 gstreamer0.10-tools
 gstreamer1.0-plugins-good
-gstreamer1.0-plugins-ugly
 gstreamer1.0-pulseaudio
 gstreamer1.0-tools
 gvfs-bin


### PR DESCRIPTION
We don't want license/patents related issues with our core image.

[endlessm/eos-shell#4966]
