### PR TITLE
Don't pull libav packages in the core image, they're not needed anymore

### DIFF
--- a/core-armhf
+++ b/core-armhf
@@ -115,11 +115,6 @@ less
 libalut0
 libasound2
 libatkmm-1.6-1
-libavcodec53
-libavdevice53
-libavfilter2
-libavformat53
-libavutil51
 libbluetooth3
 libboost-filesystem1.49.0
 libboost-iostreams1.49.0
@@ -160,7 +155,6 @@ libpam-fprintd
 libpam-runtime
 libpam-systemd
 libpangomm-1.4-1
-libpostproc52
 libpulse-mainloop-glib0
 libpulse0
 libreoffice
@@ -171,7 +165,6 @@ libsdl-net1.2
 libsdl-pango1
 libsdl-ttf2.0-0
 libsdl1.2debian
-libswscale2
 libtelepathy-farstream3
 libumfpack5.4.0
 libwpd-0.10-10

--- a/core-i386
+++ b/core-i386
@@ -120,11 +120,6 @@ less
 libalut0
 libasound2
 libatkmm-1.6-1
-libavcodec53
-libavdevice53
-libavfilter2
-libavformat53
-libavutil51
 libbluetooth3
 libboost-filesystem1.49.0
 libboost-iostreams1.49.0
@@ -168,7 +163,6 @@ libpam-fprintd
 libpam-runtime
 libpam-systemd
 libpangomm-1.4-1
-libpostproc52
 libpulse-mainloop-glib0
 libpulse0
 libreoffice
@@ -179,7 +173,6 @@ libsdl-net1.2
 libsdl-pango1
 libsdl-ttf2.0-0
 libsdl1.2debian
-libswscale2
 libtelepathy-farstream3
 libumfpack5.4.0
 libwpd-0.10-10


### PR DESCRIPTION
Due to the work related to codecs distribution, libav has stopped being
necessary in our image, either because packages depending on it (e.g.
frostwire) are not going to be included/bundled or because those that
still are have been rebuilt not to depend in libav (e.g. Audacity).

[endlessm/eos-shell#5067]
