### PR TITLE
eos-dev depends on eos-node-modules-dev

### DIFF
--- a/dev-all
+++ b/dev-all
@@ -17,6 +17,7 @@ devscripts
 diffutils
 elinks
 emacs
+eos-node-modules-dev
 exuberant-ctags
 flex
 fluxbox


### PR DESCRIPTION
eos-node-modules-dev contains Node.js modules that are used while
developing Endless OS packages, so eos-dev should bring it in.

[endlessm/eos-sdk#3085]
