### PR TITLE
Remove singularity-archive-keyring from core

### DIFF
--- a/core-armhf
+++ b/core-armhf
@@ -200,7 +200,6 @@ python-gst-1.0
 rhythmbox (>= 2.99.1)
 rtkit
 shotwell
-singularity-archive-keyring
 sudo
 system-config-printer-gnome
 systemd-sysv

--- a/core-i386
+++ b/core-i386
@@ -209,7 +209,6 @@ python-gst-1.0
 rhythmbox (>= 2.99.1)
 rtkit
 shotwell
-singularity-archive-keyring
 sudo
 system-config-printer-gnome
 systemd-sysv


### PR DESCRIPTION
This was probably never used in the first place, but certainly now
all packages come from Endless repos and not from Collabora. Neither our
users nor developers have any use for singularity's keyring.

[endlessm/eos-shell#5053]