### PR TITLE
tech-support: Adjust to new updater names

### DIFF
--- a/eos-tech-support/eos-convert-system
+++ b/eos-tech-support/eos-convert-system
@@ -10,13 +10,13 @@ echo "Configuring Metrics System for Dev"
 source eos-select-metrics-env 'dev'
 
 # Disable upgrade timer
-systemctl stop eos-updater.timer
-systemctl disable eos-updater.timer
+systemctl stop eos-autoupdater.timer
+systemctl disable eos-autoupdater.timer
 
 # Unsure if these are necessary after stopping the timer, but better to be
 # sure.
-systemctl stop eos-updater.service
-systemctl kill eos-updater.service
+systemctl stop eos-autoupdater.service
+systemctl kill eos-autoupdater.service
 
 # 4th element in mountinfo is the "root" within a mounted filesystem, 5th is
 # where it's mounted. Hence dig out where our root is coming from, so we're

--- a/eos-tech-support/eos-convert-system-qa
+++ b/eos-tech-support/eos-convert-system-qa
@@ -90,7 +90,7 @@ if $OSTREE; then
     ostree admin set-origin eos "$new_url" "$new_branch" \
         --set=branches="${new_branch};"
 
-    echo "Killing ostree-daemon."
-    killall ostree-daemon &>/dev/null
+    echo "Killing eos-updater."
+    killall eos-updater &>/dev/null
     echo "All done!"
 fi

--- a/eos-tech-support/eos-dev-fix
+++ b/eos-tech-support/eos-dev-fix
@@ -29,13 +29,13 @@ OSTREE_DEPLOY_CURRENT=$(cat /proc/self/mountinfo | \
   egrep '([^ ]* ){4}/ ' | cut -d ' ' -f 4)
 
 # Disable upgrade timer
-systemctl stop eos-updater.timer
-systemctl disable eos-updater.timer
+systemctl stop eos-autoupdater.timer
+systemctl disable eos-autoupdater.timer
 
 # Unsure if these are necessary after stopping the timer, but better to be
 # sure.
-systemctl stop eos-updater.service
-systemctl kill eos-updater.service
+systemctl stop eos-autoupdater.service
+systemctl kill eos-autoupdater.service
 
 echo  "\nAutomatic upgrades have been stopped," \
       "your system can no longer be upgraded using ostree beyond this point!"


### PR DESCRIPTION
The updater programs have changed around a bit with the ostree upgrade.
The actual updates daemon has been changed from ostree-daemon to
eos-updater as ostree-daemon has been determined to be Endless specific.
The systemd service driving the updater has been changed from
eos-updater to eos-autoupdater.

[endlessm/eos-shell#5087]