### PR TITLE
tech-support: Use admin --print-current-dir instead of current symlink

### DIFF
--- a/eos-tech-support/eos-dev-fix
+++ b/eos-tech-support/eos-dev-fix
@@ -21,12 +21,22 @@ else
   exit 1
 fi
 
-# 4th element in mountinfo is the "root" within a mounted filesystem, 5th is
-# where it's mounted. Hence dig out where our root is coming from, so we're
-# always using the _current_ root filesystem instead of the last updated
-# version
-OSTREE_DEPLOY_CURRENT=$(cat /proc/self/mountinfo | \
-  egrep '([^ ]* ){4}/ ' | cut -d ' ' -f 4)
+# Check that we're booted into the "current" deployment. Dig out the
+# booted deployment directory from the mountinfo. The 4th element in
+# mountinfo is the "root" within a mounted filesystem, 5th is where it's
+# mounted.
+OSTREE_DEPLOY_BOOTED=$(awk '{if ($5 == "/") print $4}' /proc/self/mountinfo)
+if [ -z "${OSTREE_DEPLOY_BOOTED}" ]; then
+  echo "Not booted in an ostree system - exiting" >&2
+  exit 1
+fi
+OSTREE_DEPLOY_CURRENT=$(ostree admin --print-current-dir)
+if [ $(readlink -f ${OSTREE_DEPLOY_BOOTED}) != \
+     $(readlink -f ${OSTREE_DEPLOY_CURRENT}) ] ; then
+  echo -e "\nA new system upgrade has been already deployed," \
+    "please reboot first and then run ${0} again afterwards" >&2
+  exit 1
+fi
 
 # Disable upgrade timer
 systemctl stop eos-autoupdater.timer
@@ -39,14 +49,6 @@ systemctl kill eos-autoupdater.service
 
 echo  "\nAutomatic upgrades have been stopped," \
       "your system can no longer be upgraded using ostree beyond this point!"
-
-if [ $(readlink -f ${OSTREE_DEPLOY_CURRENT}) != \
-     $(readlink -f ${OSTREE_DEPLOY}/current) ] ; then
-  echo "\nA new system upgrade has been already deployed," \
-       " please reboot first and then re-run ${0} again afterwards"
-  exit 1
-fi
-
 
 echo "Copying files from $OSTREE_DEPLOY_CURRENT"
 

--- a/eos-tech-support/eos-reset-password
+++ b/eos-tech-support/eos-reset-password
@@ -4,6 +4,7 @@
 # Except for the special shared account,
 # the user will be asked for a password on next login
 
+BOOTDEV=/dev/sda1
 DEVICE=/dev/sda2
 MOUNT=/mnt/sda2
 
@@ -33,6 +34,9 @@ fi
 
 mkdir -p $MOUNT
 mount $DEVICE $MOUNT
-sed -i "s/$USERNAME:[^:]*:[^:]*:/$USERNAME::$DATE:/" $MOUNT/ostree/deploy/eos/current/etc/shadow
+mount $BOOTDEV $MOUNT/boot
+CURRENT=$(ostree admin --sysroot=$MOUNT --print-current-dir)
+sed -i "s/$USERNAME:[^:]*:[^:]*:/$USERNAME::$DATE:/" $CURRENT/etc/shadow
+umount $MOUNT/boot
 umount $MOUNT
 rmdir $MOUNT

--- a/eos-tech-support/eos-usb-image
+++ b/eos-tech-support/eos-usb-image
@@ -25,9 +25,8 @@ fi
 # Mount two partitions using a loopback device
 LOOP_DEV=$(losetup --show -f $IMAGE)
 kpartx -a $LOOP_DEV
-BOOT_MOUNT=/mnt/image_p1
 ROOT_MOUNT=/mnt/image_p2
-mkdir -p $BOOT_MOUNT
+BOOT_MOUNT=$ROOT_MOUNT/boot
 mkdir -p $ROOT_MOUNT
 BOOT_DEV=/dev/mapper/$(basename $LOOP_DEV)p1
 ROOT_DEV=/dev/mapper/$(basename $LOOP_DEV)p2
@@ -40,22 +39,22 @@ tune2fs -U random $ROOT_DEV
 BOOT_UUID=$(blkid -s UUID -o value $BOOT_DEV)
 ROOT_UUID=$(blkid -s UUID -o value $ROOT_DEV)
 
-mount $BOOT_DEV $BOOT_MOUNT
 mount $ROOT_DEV $ROOT_MOUNT
+mount $BOOT_DEV $BOOT_MOUNT
+DEPLOY=$(ostree admin --sysroot=$ROOT_MOUNT --print-current-dir)
 
 # Change to boot based on UUID rather than label
 sed -i "/^options/s/ root=[^$ ]*/ root=UUID=$ROOT_UUID/" "$BOOT_MOUNT"/loader/entries/ostree-*.conf
-sed -i "s/^LABEL=ostree-boot/UUID=$BOOT_UUID/" "$ROOT_MOUNT"/ostree/deploy/eos/current/etc/fstab
-sed -i "s/^LABEL=ostree/UUID=$ROOT_UUID/" "$ROOT_MOUNT"/ostree/deploy/eos/current/etc/fstab
+sed -i "s/^LABEL=ostree-boot/UUID=$BOOT_UUID/" "$DEPLOY"/etc/fstab
+sed -i "s/^LABEL=ostree/UUID=$ROOT_UUID/" "$DEPLOY"/etc/fstab
 
 # Remove the swap partition, since we don't want this on a USB drive anyhow
-sed -i "/^LABEL=eos-swap/d" "$ROOT_MOUNT"/ostree/deploy/eos/current/etc/fstab
+sed -i "/^LABEL=eos-swap/d" "$DEPLOY"/etc/fstab
 
 # Reinstall grub into the boot sector
 # Our special partition 4 creates havoc for grub-install,
 # so we temporarily remove it and then revert it afterwards
 sfdisk --change-id $IMAGE 4 0
-DEPLOY="$ROOT_MOUNT"/ostree/deploy/eos/current
 grub-install --boot-directory=$BOOT_MOUNT \
              --modules="ext2 part_msdos part_gpt" \
              --directory="$DEPLOY"/usr/lib/grub/i386-pc \
@@ -65,7 +64,6 @@ sfdisk --change-id $IMAGE 4 dd
 # Unmount the partitions and cleanup the loopback device
 umount $BOOT_MOUNT
 umount $ROOT_MOUNT
-rmdir $BOOT_MOUNT
 rmdir $ROOT_MOUNT
 kpartx -d $LOOP_DEV
 losetup -d $LOOP_DEV


### PR DESCRIPTION
Newer ostree has removed the current deployment symlink and instead
offers the --print-current-dir option from ostree admin. This requires
that the boot directory is properly mounted to find the current
deployment.

Fix up a couple things on eos-dev-fix while here:

 * Use awk to scrape mountinfo in a simpler way
 * Check that we're booted in an ostree system
 * Check for an upgrade prior to stopping the automatic updater.

[endlessm/eos-shell#5189]