### PR TITLE
Add gir1.2-ostree-1.0 to core

### DIFF
--- a/core-armhf
+++ b/core-armhf
@@ -84,6 +84,7 @@ freeglut3
 gedit
 geoclue-2.0
 gettext-base
+gir1.2-ostree-1.0
 gnome-calculator
 gnome-clocks
 gnome-control-center
@@ -102,8 +103,8 @@ gstreamer0.10-plugins-base
 gstreamer0.10-plugins-good
 gstreamer0.10-pulseaudio
 gstreamer0.10-tools
-gstreamer1.0-plugins-good
 gstreamer1.0-libav
+gstreamer1.0-plugins-good
 gstreamer1.0-pulseaudio
 gstreamer1.0-tools
 gvfs-bin

--- a/core-i386
+++ b/core-i386
@@ -88,6 +88,7 @@ freeglut3
 gedit
 geoclue-2.0
 gettext-base
+gir1.2-ostree-1.0
 gnome-calculator
 gnome-clocks
 gnome-control-center
@@ -107,8 +108,8 @@ gstreamer0.10-plugins-base
 gstreamer0.10-plugins-good
 gstreamer0.10-pulseaudio
 gstreamer0.10-tools
-gstreamer1.0-plugins-good
 gstreamer1.0-libav
+gstreamer1.0-plugins-good
 gstreamer1.0-pulseaudio
 gstreamer1.0-tools
 gvfs-bin


### PR DESCRIPTION
Provide the OSTree introspection typelib so that the OSTree API can be
accessed in any way. Sort the list while here.

[endlessm/eos-shell#5195]