### PR TITLE
Add core dependency on libreoffice-gtk

### DIFF
--- a/eos-core-depends
+++ b/eos-core-depends
@@ -184,6 +184,7 @@ libpangomm-1.4-1
 libpulse-mainloop-glib0
 libpulse0
 libreoffice
+libreoffice-gtk
 libsdl-gfx1.2-4
 libsdl-image1.2
 libsdl-mixer1.2


### PR DESCRIPTION
With the Ubuntu packaging we were using for libreoffice 4.4.0 and prior,
this was a dependency of libreoffice.  With the Debian packaging we are
now using for libreoffice 4.4.4, this is no longer the case and we need
to explicitly call out the additional dependency.

[endlessm/eos-shell#5264]