### PR TITLE
Add parted to image

### DIFF
--- a/eos-core-depends
+++ b/eos-core-depends
@@ -221,6 +221,7 @@ openssh-client
 openssh-server
 ostree
 p7zip-full
+parted
 policykit-1
 printer-driver-all
 pulseaudio


### PR DESCRIPTION
This is needed in order for gnome-disks to be able to format
and manage partitions on an external drive.

[endlessm/eos-shell#5354]