### PR TITLE
Keep gir1.2-webkit2-3.0 in core

### DIFF
--- a/eos-core-depends
+++ b/eos-core-depends
@@ -95,6 +95,8 @@ gedit
 geoclue-2.0
 gettext-base
 gir1.2-ostree-1.0
+# For compatibility with 2.3 bundles:
+gir1.2-webkit2-3.0
 gnome-calculator
 gnome-clocks
 gnome-control-center


### PR DESCRIPTION
Nothing that we ship on an image currently requires it, but some bundles
from EOS 2.3 need it, so we are keeping it for compatibility reasons.

[endlessm/eos-sdk#3387]