### PR TITLE
Fix old inkscape bundles

### DIFF
--- a/eos-core-depends
+++ b/eos-core-depends
@@ -185,6 +185,8 @@ libpam-fprintd
 libpam-runtime
 libpam-systemd
 libpangomm-1.4-1
+# Older inkscape bundles depend on a specific version of poppler
+libpoppler37
 libpulse-mainloop-glib0
 libpulse0
 libreoffice


### PR DESCRIPTION
They depend on a specific version of poppler.
Since it is a relatively small library,
let's simply install two versions.

Libpoppler46 is implicitly installed as a dependency of another core
package, and here we explicitly specify a dependency on libpoppler37.

[endlessm/eos-shell#5488]