### PR TITLE
Don't install anything in /etc/skel

### DIFF
--- a/debian/eos-core.install
+++ b/debian/eos-core.install
@@ -1,3 +1,2 @@
 debian/10periodic etc/apt/apt.conf.d
 debian/defaults.list usr/share/applications
-skel etc


### PR DESCRIPTION
It's not needed any longer.

[endlessm/eos-shell#4389]