### PR TITLE
Install gdb by default

### DIFF
--- a/eos-core-depends
+++ b/eos-core-depends
@@ -92,6 +92,7 @@ fonts-vlgothic
 foomatic-db-compressed-ppds
 fprintd
 freeglut3
+gdb
 gedit
 geoclue-2.0
 gettext-base


### PR DESCRIPTION
This allows generation of backtraces on production systems.

[endlessm/eos-shell#6010]