### PR TITLE
Tech support: install screen utility

### DIFF
--- a/eos-tech-support-depends
+++ b/eos-tech-support-depends
@@ -1,4 +1,5 @@
 bash-completion
 lshw
 pv
+screen
 traceroute


### PR DESCRIPTION
Useful to allow field support to use Endless as the receiving computer
for troubleshooting via the UART serial console.

[endlessm/eos-shell#6174]