### PR TITLE
Install fake-hwclock

### DIFF
--- a/eos-core-depends
+++ b/eos-core-depends
@@ -56,6 +56,7 @@ eos-updater
 evince
 evolution
 exfat-fuse
+fake-hwclock
 file
 file-roller
 fonts-arabeyes


### PR DESCRIPTION
This script stores a timestamp on shutdown, and restores that time
on startup (unless the current time is newer, for example due to
a working battery-backed hardware clock).

This is useful for products that don't have a battery-backed
hardware clock, so that time stamps are monotonically increasing,
and NTP incremental updates are faster.

[endlessm/eos-shell#1431]