### PR TITLE
[endlessm/eos-shell#6302] Switch images to a 64-bit kernel

### DIFF
--- a/eos-core-depends
+++ b/eos-core-depends
@@ -202,7 +202,7 @@ libwpg-0.2-2
 libwpg-0.3-3
 linux-firmware
 # Platform specific kernels for arm
-linux-image-generic [!armhf]
+linux-image-generic-64 [!armhf]
 locales
 lsb-base
 lsb-release


### PR DESCRIPTION
This change depends on [OBS request 2641](https://obs-master.endlessm-sf.com/request/show/2641), please merge that one first.

We have a new kernel flavour generic-64 which provides a 64-bit kernel
as i386 packages, so they can be installed in a i386 system. Switch to
them so we can move the kernel to 64-bit while keeping a 32-bit
userspace.

[endlessm/eos-shell#6302]