### PR TITLE
Add Indonesian (id) language pack

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -134,6 +134,13 @@ Description: EndlessOS French Language Pack
  This is a collection of French language packs for the EndlessOS operating
  system.
 
+Package: eos-language-pack-id
+Architecture: all
+Depends: ${misc:Depends}, ${eos:Depends}
+Description: EndlessOS Indonesian Language Pack
+ This is a collection of Indonesian (Bahasa Indonesia) language packs
+ for the EndlessOS operating system.
+
 Package: eos-language-pack-pt
 Architecture: all
 Depends: ${misc:Depends}, ${eos:Depends}

--- a/eos-core-depends
+++ b/eos-core-depends
@@ -39,6 +39,7 @@ eos-language-pack-ar
 eos-language-pack-en
 eos-language-pack-es
 eos-language-pack-fr
+eos-language-pack-id
 eos-language-pack-pt_BR
 eos-language-pack-zh_CN
 eos-license-service

--- a/eos-language-pack-id-depends
+++ b/eos-language-pack-id-depends
@@ -1,0 +1,1 @@
+libreoffice-l10n-id


### PR DESCRIPTION
Note that there is LibreOffice help pack for Indonesian.

Also, our current KDE version does not have an Indonesian pack,
and though there is now a kde-l10n-id available in debian sid,
it does not appear to cover any of our KDE applications anyhow.

[endlessm/eos-shell#6283]