### PR TITLE
Add libcanberra-gtk3-0 dependency to eos-core and eos-platform-runtime

### DIFF
--- a/eos-core-depends
+++ b/eos-core-depends
@@ -152,6 +152,7 @@ libboost-system1.49.0
 libboost-thread1.49.0
 libcairomm-1.0-1
 libcanberra-gtk-module
+libcanberra-gtk3-0
 libcanberra-pulse
 libcaribou-gtk-module
 libcaribou-gtk3-module

--- a/eos-platform-runtime-depends
+++ b/eos-platform-runtime-depends
@@ -47,6 +47,7 @@ libboost-system1.49.0
 libboost-thread1.49.0
 libcairomm-1.0-1
 libcanberra-gtk-module
+libcanberra-gtk3-0
 libcanberra-pulse
 libcaribou-gtk-module
 libcaribou-gtk3-module


### PR DESCRIPTION
There are many xdg-app application bundles using the Endless runtime that will depend on the missing libcanberra-gtk3-0, so it seems a good idea to add it directly to the runtime. Also adding it explicitly on eos-core although it was being already pulled into by some other dep.

[endlessm/eos-shell#6291]