### PR TITLE
eos-diagnostics: add boot timing

### DIFF
--- a/eos-tech-support/eos-diagnostics
+++ b/eos-tech-support/eos-diagnostics
@@ -271,6 +271,13 @@ function dumpDiagnostics(filename) {
     fullDump += trySpawn('ps aux');
     fullDump += '\n';
 
+    fullDump += '===============\n'
+    fullDump += '= Boot timing =\n'
+    fullDump += '===============\n'
+    fullDump += '\n';
+    fullDump += trySpawn('systemd-analyze');
+    fullDump += '\n';
+
     fullDump += '==================\n';
     fullDump += '= Journal output =\n';
     fullDump += '==================\n';


### PR DESCRIPTION
Output of systemd-analyze.

[endlessm/eos-shell#6346]