### PR TITLE
Add explicit dependency on python-dbus

### DIFF
--- a/eos-core-depends
+++ b/eos-core-depends
@@ -242,6 +242,7 @@ printer-driver-all
 pulseaudio
 pulseaudio-module-bluetooth
 pulseaudio-module-x11
+python-dbus
 python-gst-1.0
 rhythmbox (>= 2.99.1)
 rtkit


### PR DESCRIPTION
This package is a required dependency of turtleblocks.

Previously, we inherently installed as a dependency of hplip,
but with an upgrade to hplip that is no longer the case.

[endlessm/eos-shell#6356]