### PR TITLE
Add explicit dependency on libglu1-mesa

### DIFF
--- a/eos-core-depends
+++ b/eos-core-depends
@@ -177,6 +177,7 @@ libgles2-mesa [!armhf]
 libglew1.8
 libglib2.0-data
 libglibmm-2.4-1c2a
+libglu1-mesa [!armhf]
 libgrilo-0.2-1
 libgtkmm-2.4-1c2a
 libgtkmm-3.0-1


### PR DESCRIPTION
This package is a required dependency of megaglest.

Previously, this was inherently installed due to a core dependency,
and that is apparently no longer the case.

[endlessm/eos-shell#6368]