### PR TITLE
Add python-gi-cairo and python-xdg to core for apps

### DIFF
--- a/eos-core-depends
+++ b/eos-core-depends
@@ -244,7 +244,11 @@ pulseaudio
 pulseaudio-module-bluetooth
 pulseaudio-module-x11
 python-dbus
+# Needed by pitivi and gnome-sudoku
+python-gi-cairo
 python-gst-1.0
+# Needed by pitivi and labyrinth
+python-xdg
 rhythmbox (>= 2.99.1)
 rtkit
 simple-scan


### PR DESCRIPTION
After upgrades to gedit and totem, these are no longer pulled into the
core, but they're needed by pitivi, gnome-sudoku and labyrinth.

[endlessm/eos-shell#6415]