### PR TITLE
allow 32-bit kernel instead of 64-bit kernel

### DIFF
--- a/eos-core-depends
+++ b/eos-core-depends
@@ -217,7 +217,7 @@ libwpg-0.2-2
 libwpg-0.3-3
 linux-firmware
 # Platform specific kernels for arm
-linux-image-generic-64 [!armhf]
+linux-image-generic-64 [!armhf] | linux-image-generic [!armhf]
 locales
 lsb-base
 lsb-release


### PR DESCRIPTION
As we have a mixed 64-bit kernel and 32-bit userland in the 2.6 series, a bunch of miscellaneous stuff (eg Spice's QXL or NVidia proprietary X drivers) gets unhappy if the userland and kernel aren't both the same, which is a pain for some developers. While we're building both kernels, you can fix this by manually installing the 32-bit kernel package if you're on a converted system. This patch allows you to remove the 64-bit kernel without breaking the eos-core dependencies, so you can makes Grub default to the 32-bit one without hacking around with the grub config or removing the eos-core metapackage and falling behind master.