### PR TITLE
eos-write-image: Do not stop when blkdiscard fails

### DIFF
--- a/eos-tech-support/eos-write-image
+++ b/eos-tech-support/eos-write-image
@@ -110,7 +110,7 @@ if ! $FORCE; then
 fi
 
 # Try to format / discard all the sectors on the device
-blkdiscard "$DEVICE" >/dev/null
+blkdiscard "$DEVICE" &>/dev/null || true
 
 if file --mime-type "$IMAGE" | grep -q gzip$; then
     # Image is gzipped


### PR DESCRIPTION
[endlessm/eos-shell#6236]