### PR TITLE
Add dependency on libglu1-mesa to xdg-app runtime

### DIFF
--- a/eos-platform-runtime-depends
+++ b/eos-platform-runtime-depends
@@ -60,6 +60,7 @@ libgles2-mesa [!armhf]
 libglew1.8
 libglib2.0-data
 libglibmm-2.4-1c2a
+libglu1-mesa [!armhf]
 libgrilo-0.2-1
 libgtkmm-2.4-1c2a
 libgtkmm-3.0-1


### PR DESCRIPTION
It is required by several packages and was already part of eos-core,
so it makes sense this becomes part of the runtime.

In the mid-term, this should not be here but in a runtime extension,
so it would be possible to load different GL libs depending on the
hardware platform.