### PR TITLE
Add eos-chrome-plugins-updater-s3 to the list of core dependencies

### DIFF
--- a/eos-core-depends
+++ b/eos-core-depends
@@ -22,6 +22,7 @@ eos-acknowledgements
 eos-app-manager
 eos-boot-helper
 eos-chrome-plugin-updater
+eos-chrome-plugin-updater-s3
 eos-codecs-manager
 eos-composite-mode
 eos-event-recorder-daemon


### PR DESCRIPTION
Note: This SHOULD BE UNDONE as soon as we move to 64-bit for Intel products.

https://phabricator.endlessm.com/T10669