### PR TITLE
Add systemd-coredump as a dependency of eos-core

### DIFF
--- a/eos-core-depends
+++ b/eos-core-depends
@@ -257,6 +257,7 @@ simple-scan
 shotwell
 sudo
 system-config-printer-gnome
+systemd-coredump
 systemd-sysv
 totem
 tracker


### PR DESCRIPTION
On our newer systemd (229) systemd-coredump and coredumpctl are part of
a separate package.

https://phabricator.endlessm.com/T6363