### PR TITLE
Add missing dependencies for xdg-app bundles

### DIFF
--- a/eos-core-depends
+++ b/eos-core-depends
@@ -159,6 +159,7 @@ libcaribou-gtk3-module
 # Mali used on arm
 libegl1-mesa-drivers [!armhf]
 libfolks-eds25
+libfribidi0
 libgc1c3
 libgfortran3
 # Mali used on arm

--- a/eos-core-depends
+++ b/eos-core-depends
@@ -156,8 +156,14 @@ libcanberra-gtk3-0
 libcanberra-pulse
 libcaribou-gtk-module
 libcaribou-gtk3-module
+libclutter-1.0-0
+libclutter-gtk-1.0-0
+libcogl20
+libcogl-pango20
+libcogl-path20
 # Mali used on arm
 libegl1-mesa-drivers [!armhf]
+libevdev2
 libfolks-eds25
 libfribidi0
 libgc1c3
@@ -173,6 +179,7 @@ libgtkmm-3.0-1
 libgtkspell3-3-0
 # Adobe flash is x86 only
 libhal1-flash [i386 amd64]
+libinput10
 libkdeedu-data
 libkdegames6abi1
 libkdegamesprivate1abi1
@@ -184,6 +191,7 @@ liblua5.1-0
 liblua5.2-0
 libnss-altfiles
 libnss-myhostname
+libmtdev1
 libpam-fprintd
 libpam-runtime
 libpam-systemd

--- a/eos-platform-runtime-depends
+++ b/eos-platform-runtime-depends
@@ -54,6 +54,7 @@ libcaribou-gtk3-module
 # Mali used on arm
 libegl1-mesa-drivers [!armhf]
 libfolks-eds25
+libfribidi0
 libgc1c3
 libgfortran3
 # Mali used on arm

--- a/eos-platform-runtime-depends
+++ b/eos-platform-runtime-depends
@@ -51,8 +51,14 @@ libcanberra-gtk3-0
 libcanberra-pulse
 libcaribou-gtk-module
 libcaribou-gtk3-module
+libclutter-1.0-0
+libclutter-gtk-1.0-0
+libcogl20
+libcogl-pango20
+libcogl-path20
 # Mali used on arm
 libegl1-mesa-drivers [!armhf]
+libevdev2
 libfolks-eds25
 libfribidi0
 libgc1c3
@@ -68,6 +74,7 @@ libgtkmm-3.0-1
 libgtkspell3-3-0
 # Adobe flash is x86 only
 libhal1-flash [i386 amd64]
+libinput10
 libkdeedu-data
 libkdegames6abi1
 libkdegamesprivate1abi1
@@ -79,6 +86,7 @@ liblua5.1-0
 liblua5.2-0
 libnss-altfiles
 libnss-myhostname
+libmtdev1
 libpam-fprintd
 libpam-runtime
 libpam-systemd


### PR DESCRIPTION
In order to run some of the sandboxed xdg-app bundles that are being produced, there are still some missing dependencies in the runtime. Also making them explicit on eos-core although they were already being already pulled into by some other dep.