### PR TITLE
Explicitly depend on brasero

### DIFF
--- a/eos-core-depends
+++ b/eos-core-depends
@@ -7,6 +7,7 @@ apt-utils
 attr
 avahi-daemon
 bluez
+brasero
 btrfs-tools
 bzip2
 ca-certificates


### PR DESCRIPTION
Previously, we relied an eos-file-manager recommending brasero,
but the latest version of nautilus merely suggests brasero,
so it was not getting installed.

https://phabricator.endlessm.com/T11139