### PR TITLE
Change libgc depdendency to libgc1c2

### DIFF
--- a/eos-core-depends
+++ b/eos-core-depends
@@ -180,7 +180,7 @@ libegl1-mesa-drivers [!armhf]
 libevdev2
 libfolks-eds25
 libfribidi0
-libgc1c3
+libgc1c2
 libgfortran3
 # Mali used on arm
 libgles2-mesa [!armhf]

--- a/eos-platform-runtime-depends
+++ b/eos-platform-runtime-depends
@@ -61,7 +61,7 @@ libegl1-mesa-drivers [!armhf]
 libevdev2
 libfolks-eds25
 libfribidi0
-libgc1c3
+libgc1c2
 libgfortran3
 # Mali used on arm
 libgles2-mesa [!armhf]


### PR DESCRIPTION
In moving back to the Debian version of libgc, they've kept the library
at libgc1c2 rather than changing it to libgc1c3 like Ubuntu did. Update
the core/platform dependency accordingly.

https://phabricator.endlessm.com/10823