### PR TITLE
Add imagescan to the core dependencies, needed for some Epson scanners

### DIFF
--- a/eos-core-depends
+++ b/eos-core-depends
@@ -140,6 +140,8 @@ ibus-table-wubi
 ibus-tegaki
 ibus-unikey
 icedtea-plugin
+# Needed to support some Epson scanners
+imagescan
 iproute
 kde-games-core-declarative
 kde-runtime


### PR DESCRIPTION
https://phabricator.endlessm.com/T11319