### PR TITLE
eos-launch-all: fix launching of core apps

### DIFF
--- a/eos-tech-support/eos-launch-all
+++ b/eos-tech-support/eos-launch-all
@@ -5,7 +5,7 @@ failed_apps=()
 
 script=`basename $0`
 
-CORE_APPS=/usr/share/applications/eos-app-*.desktop
+CORE_APPS=`grep -Rl X-Endless-Merged /usr/share/applications | sort`
 BUNDLE_APPS=/endless/share/applications/*.desktop
 
 for desktop in $CORE_APPS $BUNDLE_APPS


### PR DESCRIPTION
We no longer prefix the desktop names with "eos-app-",
so instead we can now check for the "X-Endless-Merged" field
inside the dekstop file to isolate which core apps
we expose to the user via desktop icons.

https://phabricator.endlessm.com/T10982