### PR TITLE
Depend on libglew1.10

### DIFF
--- a/eos-core-depends
+++ b/eos-core-depends
@@ -185,7 +185,7 @@ libgc1c2
 libgfortran3
 # Mali used on arm
 libgles2-mesa [!armhf]
-libglew1.8
+libglew1.10
 libglib2.0-data
 libglibmm-2.4-1c2a
 libglu1-mesa [!armhf]

--- a/eos-platform-runtime-depends
+++ b/eos-platform-runtime-depends
@@ -65,7 +65,7 @@ libgc1c2
 libgfortran3
 # Mali used on arm
 libgles2-mesa [!armhf]
-libglew1.8
+libglew1.10
 libglib2.0-data
 libglibmm-2.4-1c2a
 libglu1-mesa [!armhf]


### PR DESCRIPTION
glew got updated. Some app rebuilds will be needed to link to the new
version of libglew.

https://phabricator.endlessm.com/T10823