### PR TITLE
Update libumfpack dependency

### DIFF
--- a/eos-core-depends
+++ b/eos-core-depends
@@ -223,7 +223,7 @@ libsdl-pango1
 libsdl-ttf2.0-0
 libsdl1.2debian
 libswscale3
-libumfpack5.4.0
+libumfpack5.6.2
 libwpd-0.10-10
 libwpg-0.3-3
 linux-firmware

--- a/eos-platform-runtime-depends
+++ b/eos-platform-runtime-depends
@@ -102,7 +102,7 @@ libsdl-pango1
 libsdl-ttf2.0-0
 libsdl1.2debian
 libswscale3
-libumfpack5.4.0
+libumfpack5.6.2
 libwpd-0.10-10
 libwpd-0.9-9
 libwpg-0.2-2


### PR DESCRIPTION
suitesparse is being updated, so depend on the new libumfpack5.6.2. Some
apps will need to be rebuilt to link to the new version.

https://phabricator.endlessm.com/T10823