### PR TITLE
T11374: convert-system: Disable /boot bind mount

### DIFF
--- a/eos-tech-support/eos-convert-system
+++ b/eos-tech-support/eos-convert-system
@@ -17,6 +17,9 @@ systemctl disable eos-autoupdater.timer
 # sure.
 systemctl stop eos-autoupdater.service
 
+# Disable the /boot bind mount
+systemctl disable boot.mount
+
 # 4th element in mountinfo is the "root" within a mounted filesystem, 5th is
 # where it's mounted. Hence dig out where our root is coming from, so we're
 # always using the _current_ root filesystem instead of the last updated


### PR DESCRIPTION
On converted systems the root partition is not mounted to /sysroot, so
/sysroot/boot should not be mounted over /boot.

https://phabricator.endlessm.com/T11374