### PR TITLE
Remove explicitly dependency on gir1.2-webkit2-3.0

### DIFF
--- a/eos-core-depends
+++ b/eos-core-depends
@@ -41,7 +41,6 @@ eos-metrics-instrumentation
 evolution
 gdb
 # For compatibility with 2.3 bundles:
-gir1.2-webkit2-3.0
 gstreamer0.10-tools
 icedtea-plugin
 # Needed to support some Epson scanners


### PR DESCRIPTION
This package is no longer available from webkigtk > 2.4.9, so let's
remove it from here. Note that this will break the Virtual School
bundle from EOS 2.3, but considering that would be a pretty old
bundle at the time the user gets the 2.7 release, and that we will
have to migrate a lot of stuff anyway because of the 32bit > 64bit
switch, this actually seems like a good moment to get rid of it.

For more information on why this dependency has been introduced,
please check this out: https://phabricator.endlessm.com/T9824

https://phabricator.endlessm.com/T11388