### PR TITLE
Disable /boot bind-mount on dist-upgrade

### DIFF
--- a/debian/eos-tech-support.postinst
+++ b/debian/eos-tech-support.postinst
@@ -1,0 +1,4 @@
+#DEBHELPER#
+
+# Disable the /boot bind mount on dist-upgrade
+systemctl disable boot.mount


### PR DESCRIPTION
We need to disable boot.mount on dist-upgrade as well, to cover
previously converted systems.

https://phabricator.endlessm.com/T11374