### PR TITLE
T11374: Revert "convert-system: Disable /boot bind mount"

### DIFF
--- a/eos-tech-support/eos-convert-system
+++ b/eos-tech-support/eos-convert-system
@@ -17,9 +17,6 @@ systemctl disable eos-autoupdater.timer
 # sure.
 systemctl stop eos-autoupdater.service
 
-# Disable the /boot bind mount
-systemctl disable boot.mount
-
 # 4th element in mountinfo is the "root" within a mounted filesystem, 5th is
 # where it's mounted. Hence dig out where our root is coming from, so we're
 # always using the _current_ root filesystem instead of the last updated


### PR DESCRIPTION
This reverts commit c11becad03162206f84b62a394cec12658e5df3c.

Don't disable the boot.mount unit on eos-convert-system, since now its
execution is controlled by conditionals on the unit file.

https://phabricator.endlessm.com/T11374