### PR TITLE
core: Disable plugin updaters on amd64

### DIFF
--- a/eos-core-depends
+++ b/eos-core-depends
@@ -21,11 +21,11 @@ eos-chrome-plugin-updater-s3
 eos-codecs-manager
 eos-event-recorder-daemon
 eos-exploration-center
-# Flash plugin only for x86 arches
-eos-flashplugin-updater [i386 amd64]
+# Flash plugin only for i386 right now
+eos-flashplugin-updater [i386]
 eos-gates
-# Google Talk plugin only for x86 arches
-eos-google-talkplugin-updater [i386 amd64]
+# Google Talk plugin only for i386 right now
+eos-google-talkplugin-updater [i386]
 eos-language-pack-ar
 eos-language-pack-bn
 eos-language-pack-en


### PR DESCRIPTION
We don't even build the packages yet for these, so they're just causing
the ostree build to fail.

https://phabricator.endlessm.com/T11417