### PR TITLE
Add gnome-software to OS dependencies

### DIFF
--- a/os-depends
+++ b/os-depends
@@ -61,6 +61,7 @@ gnome-initial-setup
 gnome-orca
 gnome-screenshot
 gnome-session
+gnome-software
 gnome-sushi
 gnome-system-monitor
 gnome-terminal


### PR DESCRIPTION
I am assuming that *os-dependencies* is the right place to add *gnome-software*. Otherwise just let me know.