### PR TITLE
Add xdg-app to base depends

### DIFF
--- a/eos-core-depends
+++ b/eos-core-depends
@@ -57,3 +57,4 @@ rhythmbox (>= 2.99.1)
 unoconv
 unrar
 whiptail
+xdg-app


### PR DESCRIPTION
xdg-app is a main component for the 2.7 release so we should have it
added by default in the images.