### PR TITLE
Add libcurl3 to the platform runtime

### DIFF
--- a/eos-platform-runtime-depends
+++ b/eos-platform-runtime-depends
@@ -5,6 +5,7 @@ include app-depends
 include base-depends
 
 # Other app specific dependencies
+libcurl3
 libsdl-gfx1.2-4
 libwpd-0.9-9
 libwpg-0.2-2


### PR DESCRIPTION
libcurl3 will be needed for Spotify when we use it as an xdg-app
and it is common enough to ship it for other apps.