### PR TITLE
Switch to libinput

### DIFF
--- a/os-depends
+++ b/os-depends
@@ -136,8 +136,7 @@ xdg-user-dirs
 xdg-user-dirs-gtk
 xkb-data-i18n
 xserver-xorg
-xserver-xorg-input-evdev
-xserver-xorg-input-synaptics
+xserver-xorg-input-libinput
 # Some of these are really specific to x86, but just keep them off of arm for now
 xserver-xorg-video-amdgpu [!armhf]
 # Generic ARM X driver


### PR DESCRIPTION
Make the core os packages pull the libinput X input driver instead of
synaptics and evdev.

https://phabricator.endlessm.com/T11530