### PR TITLE
Add libpython2.7 to app dependencies

### DIFF
--- a/app-depends
+++ b/app-depends
@@ -61,6 +61,7 @@ libmtdev1
 libpangomm-1.4-1
 libpulse0
 libpulse-mainloop-glib0
+libpython2.7
 libsdl1.2debian
 libsdl-image1.2
 libsdl-mixer1.2


### PR DESCRIPTION
Required by gcompris and probably by other apps.

https://phabricator.endlessm.com/T11355