### PR TITLE
tech-support: Remount /usr rw before eos-convert-passwd

### DIFF
--- a/eos-tech-support/eos-convert-system
+++ b/eos-tech-support/eos-convert-system
@@ -71,7 +71,7 @@ ln -s /home /sysroot/sysroot/
 # Merge the passwd and group files from /lib back into the corresponding
 # files in /etc so that debian maintainer scripts can update them as
 # they expect.
-eos-convert-passwd
+eos-convert-passwd --root=/sysroot
 
 # Make the systemd journal persistent
 mkdir /var/log/journal


### PR DESCRIPTION
/usr needs to be remounted rw before running eos-convert-passwd, so it
can remove /lib/passwd in the end of the process.

https://phabricator.endlessm.com/T11487