### PR TITLE
Add python-cairo to app-depends

### DIFF
--- a/app-depends
+++ b/app-depends
@@ -72,4 +72,5 @@ libswscale3
 libumfpack5.6.2
 libwpd-0.10-10
 libwpg-0.3-3
+python-cairo
 python-gst-1.0


### PR DESCRIPTION
Required by GCompris and probably by other apps.

https://phabricator.endlessm.com/T11355