### PR TITLE
Add eos-installer-meta metapackage

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -88,6 +88,30 @@ Description: Target packages of the Endless distribution for odroidu2
  .
  This set provides the platform specific package list for armhf-ec100
 
+Package: eos-installer-meta
+Architecture: any
+Depends: ${misc:Depends}, ${eos:Depends}
+Description: Target packages of the Endless installer
+ This metapackage depends on all packages required for the Endless
+ installer tool.
+
+Package: eos-installer-meta-i386
+Architecture: i386
+Depends: ${misc:Depends}, ${eos:Depends}
+Description: Target packages of the Endless installer
+ This metapackage depends on all packages required for the Endless
+ installer tool.
+ .
+ This set provides the platform specific package list for i386.
+
+Package: eos-installer-meta-ec100
+Architecture: armhf
+Depends: ${misc:Depends}, ${eos:Depends}
+Description: Target packages of the Endless installer
+ This metapackage depends on all packages required for the Endless
+ installer tool.
+ .
+ This set provides the platform specific package list for armhf-ec100.
 
 Package: eos-apps
 Architecture: any

--- a/eos-installer-meta-depends
+++ b/eos-installer-meta-depends
@@ -1,0 +1,192 @@
+# Metapackage for the installer tool
+adduser
+attr
+avahi-daemon
+bluez
+bzip2
+ca-certificates
+chromium-browser
+cups
+dbus-x11
+dosfstools
+dracut
+eos-boot-helper
+eos-composite-mode
+eos-factory-tools
+eos-keyring
+eos-license-service
+eos-plymouth-theme
+eos-shell
+eos-social
+eos-speedwagon
+eos-tech-support
+eos-theme
+eos-tutorial
+eos-updater
+evince
+exfat-fuse
+fake-hwclock
+file
+file-roller
+fonts-arabeyes
+fonts-arphic-ukai
+fonts-arphic-uming
+fonts-cabinsketch
+fonts-crosextra-caladea
+fonts-crosextra-carlito
+fonts-dejavu
+fonts-dosis
+fonts-droid
+fonts-dustin
+fonts-farsiweb
+fonts-gargi
+fonts-indic
+fonts-kacst
+fonts-khmeros
+fonts-knda
+fonts-lato
+fonts-liberation
+fonts-nanum
+fonts-nanum-coding
+fonts-ocr-a
+fonts-paktype
+fonts-quattrocento
+fonts-roboto
+fonts-sil-andika
+fonts-sil-padauk
+fonts-thai-tlwg
+fonts-tlwg-waree
+fonts-ubuntu-font-family-console
+fonts-unfonts-core
+fonts-vlgothic
+foomatic-db-compressed-ppds
+fprintd
+gedit
+geoclue-2.0
+gettext-base
+gir1.2-ostree-1.0
+gnome-calculator
+gnome-clocks
+gnome-control-center
+gnome-initial-setup
+gnome-orca
+gnome-screenshot
+gnome-session
+gnome-sushi
+gnome-system-monitor
+gnome-terminal
+gnome-themes-standard
+gnupg
+grilo-plugins-0.2
+# Could just be i386 amd64, but theoretically supports other arches
+grub2 [!armhf]
+grub-efi-amd64-image [!armhf]
+gstreamer1.0-libav
+gstreamer1.0-plugins-good
+gstreamer1.0-pulseaudio
+gstreamer1.0-tools
+gvfs-bin
+ibus-anthy
+ibus-cangjie
+ibus-chewing
+ibus-hangul
+ibus-input-pad
+ibus-libpinyin
+ibus-libthai
+ibus-libzhuyin
+ibus-m17n
+ibus-table-wubi
+ibus-tegaki
+ibus-unikey
+iproute
+kde-games-core-declarative
+kde-runtime
+kdeedu-kvtml-data
+khelpcenter4
+less
+libcanberra-pulse
+libcaribou-gtk3-module
+# Mali used on arm
+libegl1-mesa-drivers [!armhf]
+# Mali used on arm
+libgles2-mesa [!armhf]
+libglib2.0-data
+libglu1-mesa [!armhf]
+# Adobe flash is x86 only
+libhal1-flash [i386 amd64]
+libnss-altfiles
+libnss-myhostname
+libpam-fprintd
+libpam-runtime
+libpam-systemd
+linux-firmware
+# Platform specific kernels for arm
+linux-image-generic-64 [!armhf]
+locales
+lsb-base
+lsb-release
+lzma
+mawk
+mobile-broadband-provider-info
+module-init-tools
+nautilus
+net-tools
+netbase
+network-manager
+network-manager-gnome
+network-manager-vpnc-gnome
+ntp
+obexd-client
+openprinting-ppds
+openssh-client
+openssh-server
+ostree
+p7zip-full
+parted
+policykit-1
+printer-driver-all
+pulseaudio
+pulseaudio-module-bluetooth
+pulseaudio-module-x11
+python-dbus
+rtkit
+simple-scan
+shotwell
+sudo
+system-config-printer-gnome
+systemd-sysv
+totem
+tracker
+ttf-ancient-fonts
+ttf-femkeklaver
+ttf-freefont
+ttf-sil-gentium-basic
+ttf-ubuntu-font-family
+ttf-uralic
+ttf-wqy-microhei
+ttf-wqy-zenhei
+# ARM boot loader
+u-boot-tools [armhf]
+udev
+usb-modeswitch
+vim-tiny
+vinagre
+vino
+wpasupplicant
+xauth
+xdg-user-dirs
+xdg-user-dirs-gtk
+xdg-utils
+xkb-data-i18n
+xserver-xorg
+xserver-xorg-input-evdev
+xserver-xorg-input-synaptics
+# Generic ARM X driver
+xserver-xorg-video-armsoc [armhf]
+# Some of these are really specific to x86, but just keep them off of arm for now
+xserver-xorg-video-intel [!armhf]
+xserver-xorg-video-nouveau [!armhf]
+xserver-xorg-video-qxl [!armhf]
+xserver-xorg-video-radeon [!armhf]
+xserver-xorg-video-vesa [!armhf]
+xserver-xorg-video-vmware [!armhf]

--- a/eos-installer-meta-ec100-depends
+++ b/eos-installer-meta-ec100-depends
@@ -1,0 +1,4 @@
+eos-installer-meta
+mali400-drivers-meson8
+linux-image-3.10-trunk-meson8b
+u-boot-meson-m201

--- a/eos-installer-meta-i386-depends
+++ b/eos-installer-meta-i386-depends
@@ -1,0 +1,1 @@
+eos-installer-meta


### PR DESCRIPTION
This will be used for a minimal USB OS/image for flashing Endless images
to disks. The idea is to have a minimal desktop that starts directly
into a flashing tool. This is a cut down eos-core with almost all of the
explicit library dependencies have been removed as it's expected that
they'll be pulled in as necessary by other packages.

The eos-installer-meta name is used to prevent a collision with the
likely eos-installer package that will provide the actual flashing tool.

This is a backport of e086088 without the refactoring to split up the
depends files into common subsets.

https://phabricator.endlessm.com/T11283