### PR TITLE
platform: Drop compat libraries

### DIFF
--- a/eos-platform-runtime-depends
+++ b/eos-platform-runtime-depends
@@ -3,8 +3,3 @@
 # Base dependencies shared between core and runtime
 include app-depends
 include base-depends
-
-# Other app specific dependencies
-libsdl-gfx1.2-4
-libwpd-0.9-9
-libwpg-0.2-2


### PR DESCRIPTION
These packages are only available in the shared repo because reprepro
doesn't remove them, but we don't have them for amd64. As it is, on
master the apps should be fixed up to depend on the current versions of
these libraries. Eventually the entire app-depends file will be moved
into the platform depends file when we no longer support bundles.

https://phabricator.endlessm.com/T11586