### PR TITLE
eos-convert-system: add back rlimit parameter to core pattern

### DIFF
--- a/eos-tech-support/eos-convert-system
+++ b/eos-tech-support/eos-convert-system
@@ -78,7 +78,7 @@ mkdir /var/log/journal
 
 # Enable systemd coredumps storage
 echo "Enabling systemd coredumps processing and storage"
-echo "kernel.core_pattern=|/lib/systemd/systemd-coredump %p %u %g %s %t %e" > /etc/sysctl.d/50-coredump.conf
+echo "kernel.core_pattern=|/lib/systemd/systemd-coredump %p %u %g %s %t %c %e" > /etc/sysctl.d/50-coredump.conf
 
 if [ -L /boot/uEnv.txt ] ; then 
   # Running on ARM


### PR DESCRIPTION
This was lost when systemd-coredump started requiring more parameters
after the last systemd upgrade.

https://phabricator.endlessm.com/T11631