### PR TITLE
Do not allow to run eos-launch-all with superuser privileges

### DIFF
--- a/eos-tech-support/eos-launch-all
+++ b/eos-tech-support/eos-launch-all
@@ -8,6 +8,12 @@ script=`basename $0`
 CORE_APPS=`grep -Rl X-Endless-Merged /usr/share/applications | sort`
 BUNDLE_APPS=/endless/share/applications/*.desktop
 
+USERID=`id -u`
+if [ $USERID = 0 ]; then
+    echo "Not allowed to run this program with superuser privileges"
+    exit 1
+fi
+
 for desktop in $CORE_APPS $BUNDLE_APPS
 do
     echo $desktop


### PR DESCRIPTION
Otherwise, we might run into the situation where the regular user can't
properly run some apps afterwards, as all the permissions will be broken.

https://phabricator.endlessm.com/T11630