### PR TITLE
Add default background for installer

### DIFF
--- a/os-depends
+++ b/os-depends
@@ -5,6 +5,7 @@ dosfstools
 dracut
 eos-boot-helper
 eos-composite-mode
+eos-default-background
 eos-factory-tools
 eos-license-service
 eos-plymouth-theme


### PR DESCRIPTION
Otherwise, we'll just get a solid blue background.
Note that this is just a single background image that will serve
all languages, without any regional customization like we have
for the full OS.

https://phabricator.endlessm.com/T11712