### PR TITLE
installer: Include eos-image-keyring

### DIFF
--- a/eos-installer-meta-depends
+++ b/eos-installer-meta-depends
@@ -4,4 +4,5 @@
 include base-depends
 include os-depends
 
+eos-image-keyring
 eos-installer


### PR DESCRIPTION
This will provide the image signing keys in
/usr/share/keyrings/eos-image-keyring.gpg, and the installer will use it
to verify downloaded images.

https://phabricator.endlessm.com/T11727