### PR TITLE
Follow split of eos-theme binary packages

### DIFF
--- a/base-depends
+++ b/base-depends
@@ -5,6 +5,7 @@ avahi-daemon
 bluez
 bzip2
 ca-certificates
+eos-icon-theme
 eos-keyring
 file
 fonts-liberation

--- a/eos-platform-runtime-depends
+++ b/eos-platform-runtime-depends
@@ -3,3 +3,5 @@
 # Base dependencies shared between core and runtime
 include app-depends
 include base-depends
+
+eos-extra-fonts

--- a/os-depends
+++ b/os-depends
@@ -6,12 +6,12 @@ dracut
 eos-boot-helper
 eos-composite-mode
 eos-default-background
+eos-default-settings
 eos-factory-tools
 eos-license-service
 eos-plymouth-theme
 eos-shell
 eos-tech-support
-eos-theme
 eos-updater
 exfat-fuse
 fake-hwclock


### PR DESCRIPTION
eos-default-settings only belongs to the OS.
eos-icon-theme belongs to both the OS and the runtime.
eos-extra-fonts only belongs to the runtime.

https://phabricator.endlessm.com/T11779