### PR TITLE
eos-add-to-desktop: new script

### DIFF
--- a/eos-tech-support/eos-add-to-desktop
+++ b/eos-tech-support/eos-add-to-desktop
@@ -1,0 +1,17 @@
+#!/bin/bash -e
+
+# Adds an application to the dekstop
+# The appname.dekstop file must already exist (typically in
+# /usr/share/applications or ~/.local/share/applications)
+
+if [ $# -lt 1 ] ; then
+    echo "Usage:"
+    echo "   $0 appid"
+    echo "Where:"
+    echo "   appid = application id (where desktop file is named appid.desktop)"
+    exit
+fi
+
+APPID="$1"
+
+dbus-send --session --type=method_call --dest=org.gnome.Shell /org/gnome/Shell org.gnome.Shell.AppStore.AddApplication string:$APPID.desktop


### PR DESCRIPTION
Adds an application with the specified app ID to the desktop
(where the appid.desktop file already exists).

https://phabricator.endlessm.com/T11824