### PR TITLE
eos-convert-system: add -p to mkdir

### DIFF
--- a/eos-tech-support/eos-convert-system
+++ b/eos-tech-support/eos-convert-system
@@ -65,7 +65,7 @@ find /sysroot/{bin,etc,lib,sbin,usr,opt,var} -xdev -type f -size 0 -links +2 \
 # to the real /home.
 # Note that making /syroot a symlink to / fails as dracut will 
 # pick that up when re-generating the initramfs and blow up
-mkdir /sysroot/sysroot
+mkdir -p /sysroot/sysroot
 ln -s /home /sysroot/sysroot/
 
 # Merge the passwd and group files from /lib back into the corresponding
@@ -74,7 +74,7 @@ ln -s /home /sysroot/sysroot/
 eos-convert-passwd --root=/sysroot
 
 # Make the systemd journal persistent
-mkdir /var/log/journal
+mkdir -p /var/log/journal
 
 # Enable systemd coredumps storage
 echo "Enabling systemd coredumps processing and storage"


### PR DESCRIPTION
Don't error out if a directory (e.g., the journal) already exists.

https://phabricator.endlessm.com/T11889