### PR TITLE
eos-core-depends: Add uuid-runtime

### DIFF
--- a/eos-core-depends
+++ b/eos-core-depends
@@ -137,6 +137,7 @@ ttf-wqy-microhei
 ttf-wqy-zenhei
 unoconv
 unrar
+uuid-runtime
 vinagre
 vino
 virtualbox-guest-utils [amd64]


### PR DESCRIPTION
https://phabricator.endlessm.com/T12003
