### PR TITLE
eos-convert-system: Check if we're running under secure boot

### DIFF
--- a/eos-tech-support/eos-check-secureboot
+++ b/eos-tech-support/eos-check-secureboot
@@ -1,0 +1,9 @@
+#!/usr/bin/python
+# Check if we are under secure boot by reading the correspondent EFI var
+
+EFIVARS = "/sys/firmware/efi/vars"
+SECUREBOOT ="SecureBoot-8be4df61-93ca-11d2-aa0d-00e098032b8c"
+
+f = open(EFIVARS + "/" + SECUREBOOT + "/data", "rb");
+secure_boot = ord(f.read(1))
+exit(secure_boot)

--- a/eos-tech-support/eos-convert-system
+++ b/eos-tech-support/eos-convert-system
@@ -5,6 +5,11 @@ if [ ! -L /ostree ]; then
   exit 1
 fi
 
+if ! eos-check-secureboot; then
+  echo "Error: Secure boot needs to be disabled before running $0" >&2
+  exit 1
+fi
+
 # Set the metrics system to use the dev environment
 echo "Configuring Metrics System for Dev"
 source eos-select-metrics-env 'dev'


### PR DESCRIPTION
Secure boot should be disabled before running eos-convert-system,
because the kernel in our package will not be signed

https://phabricator.endlessm.com/T12159