### PR TITLE
check-secureboot: Handle absence of the EFI vars

### DIFF
--- a/eos-tech-support/eos-check-secureboot
+++ b/eos-tech-support/eos-check-secureboot
@@ -4,6 +4,9 @@
 EFIVARS = "/sys/firmware/efi/vars"
 SECUREBOOT ="SecureBoot-8be4df61-93ca-11d2-aa0d-00e098032b8c"
 
-f = open(EFIVARS + "/" + SECUREBOOT + "/data", "rb");
+try:
+    f = open(EFIVARS + "/" + SECUREBOOT + "/data", "rb");
+except IOError:
+    exit(0)
 secure_boot = ord(f.read(1))
 exit(secure_boot)


### PR DESCRIPTION
If the EFI variable file is not found our python code exits with an
error, what is equivalent to reporting secureboot is enabled. Catch the
IOError exception and report we're not under secure boot.

https://phabricator.endlessm.com/T12159