### PR TITLE
os: Install shim-efi-image only on amd64

### DIFF
--- a/os-depends
+++ b/os-depends
@@ -59,7 +59,7 @@ policykit-1
 pulseaudio
 pulseaudio-module-bluetooth
 pulseaudio-module-x11
-shim-efi-image [!armhf]
+shim-efi-image [amd64]
 sudo
 systemd-sysv
 # ARM boot loader


### PR DESCRIPTION
Shim is only built on amd64, and it will only ever work on amd64 as far
as I know. Without this, the i386 builds are broken.

https://phabricator.endlessm.com/T12093