### PR TITLE
Add ruby-sass to the SDK dependencies

### DIFF
--- a/eos-sdk-runtime-depends
+++ b/eos-sdk-runtime-depends
@@ -25,6 +25,8 @@ libsoup2.4-dev
 make
 patchutils
 quilt
+ruby-compass
+ruby-sass
 strace
 valgrind
 vim


### PR DESCRIPTION
This is typically needed to build Endless apps.