### PR TITLE
core: Add cdrdao

### DIFF
--- a/eos-core-depends
+++ b/eos-core-depends
@@ -10,6 +10,7 @@ apt-transport-https
 apt-utils
 brasero
 btrfs-tools
+cdrdao
 cheese
 chromium-browser
 cups


### PR DESCRIPTION
Provides cdrdao and toc2cue binaries, which are required by brasero
to record a music CD.

https://phabricator.endlessm.com/T12145