### PR TITLE
core: Add smbclient

### DIFF
--- a/eos-core-depends
+++ b/eos-core-depends
@@ -118,6 +118,7 @@ rhythmbox (>= 2.99.1)
 rtkit
 shotwell
 simple-scan
+smbclient
 system-config-printer-gnome
 systemd-coredump
 totem


### PR DESCRIPTION
Provides the "smb" backend to CUPS for printers shared from Windows.

https://phabricator.endlessm.com/T12148