### PR TITLE
core: Add eos-kalite-system-helper

### DIFF
--- a/eos-core-depends
+++ b/eos-core-depends
@@ -23,6 +23,7 @@ eos-codecs-manager
 eos-event-recorder-daemon
 eos-exploration-center
 eos-gates
+eos-kalite-system-helper
 eos-language-pack-ar
 eos-language-pack-bn
 eos-language-pack-en


### PR DESCRIPTION
This package is needed for the KA Lite flatpak to work, as it provides
the OS-related bits like the kalite user and integration with systemd.

https://phabricator.endlessm.com/T4489