### PR TITLE
flatpak: Include missing app-depends for audacity

### DIFF
--- a/eos-platform-runtime-depends
+++ b/eos-platform-runtime-depends
@@ -70,6 +70,7 @@ liblua5.1-0
 liblua5.2-0
 libmtdev1
 libpangomm-1.4-1
+libportaudio2
 libpulse0
 libpulse-mainloop-glib0
 libpython2.7
@@ -79,6 +80,7 @@ libsdl-mixer1.2
 libsdl-net1.2
 libsdl-pango1
 libsdl-ttf2.0-0
+libsoundtouch0
 libswscale3
 libumfpack5.6.2
 libwebkit2gtk-4.0-37


### PR DESCRIPTION
It's necessary to add libportaudio2 and libsoundtouch0 to the
runtime for the net.sourceforge.Audacity flatpak.

https://phabricator.endlessm.com/T12376