### PR TITLE
core: Add crypsetup, needed to support LUKS based encryption

### DIFF
--- a/os-depends
+++ b/os-depends
@@ -2,6 +2,7 @@
 adduser
 avahi-daemon
 bluez
+cryptsetup
 dbus-x11
 dconf-cli
 dosfstools


### PR DESCRIPTION
This is not only useful for setting up encryption for local partitions,
but also to access external encrypted drives, so it would be interesting
to add it (e.g. I backup to an encrypted USB Hard Drive).

https://phabricator.endlessm.com/T12451