### PR TITLE
eos-diagnostic: Add and "Audio info" section with the output of pactl list

### DIFF
--- a/eos-tech-support/eos-diagnostics
+++ b/eos-tech-support/eos-diagnostics
@@ -228,6 +228,13 @@ function dumpDiagnostics(filename) {
     fullDump += trySpawn('xrandr -q --verbose');
     fullDump += '\n';
 
+    fullDump += '=====================\n'
+    fullDump += '= Audio information =\n'
+    fullDump += '=====================\n'
+    fullDump += '\n';
+    fullDump += trySpawn('pactl list');
+    fullDump += '\n';
+
     fullDump += '======================\n'
     fullDump += '= Device information =\n'
     fullDump += '======================\n'


### PR DESCRIPTION
This should help common situations where the audio hardware is detected but,
for some reason, weird things still happen (e.g. audio sink muted).

https://phabricator.endlessm.com/T12455