### PR TITLE
Revert "Add explicit dependency on python-dbus"

### DIFF
--- a/eos-core-depends
+++ b/eos-core-depends
@@ -114,7 +114,6 @@ obexd-client
 openprinting-ppds
 openssh-server
 printer-driver-all
-python-dbus
 rhythmbox (>= 2.99.1)
 rtkit
 shotwell


### PR DESCRIPTION
This reverts commit 9f9bce37cc18044fae3aa4dd6686228944e91f2e.

Like the original commit says, this was only needed for turtleblocks,
which does not depend on core OS components anymore.

Conflicts:
	eos-core-depends

https://phabricator.endlessm.com/T12527