### PR TITLE
Remove icedtea-plugin from core OS

### DIFF
--- a/eos-core-depends
+++ b/eos-core-depends
@@ -103,7 +103,6 @@ ibus-libzhuyin
 ibus-m17n
 ibus-table-wubi
 ibus-unikey
-icedtea-plugin
 # Needed to support some Epson scanners
 imagescan
 libreoffice


### PR DESCRIPTION
It's not supported in Chromium anymore.

https://phabricator.endlessm.com/T12638