### PR TITLE
runtime: add openjdk-7-jre

### DIFF
--- a/eos-platform-runtime-depends
+++ b/eos-platform-runtime-depends
@@ -92,6 +92,7 @@ libwebkit2gtk-4.0-37
 libwpd-0.10-10
 libwpg-0.3-3
 libxss1
+openjdk-7-jre
 python-cairo
 python-gi
 python-gi-cairo


### PR DESCRIPTION
This is needed for apps like Frostwire.

https://phabricator.endlessm.com/T12539