### PR TITLE
eos-convert-system: Handle /var/lib/flatpak symlink

### DIFF
--- a/eos-tech-support/eos-convert-system
+++ b/eos-tech-support/eos-convert-system
@@ -64,6 +64,13 @@ done
 echo "Overlaying deployed /var FROM ${OSTREE_DEPLOY}"
 cp -paxl ${OSTREE_DEPLOY}/var /sysroot
 
+# To properly share objects with ostree, /var/lib/flatpak is a symlink
+# to /sysroot/flatpak. Since /sysroot will become /, point the symlink
+# to /flatpak instead.
+if [ "$(readlink -f /var/lib/flatpak)" = /sysroot/flatpak ]; then
+  ln -sfT /flatpak /var/lib/flatpak
+fi
+
 # Break any unwanted hard links. We assume that only empty files with
 # multiple links are unwanted and were created by ostree. Otherwise,
 # assume that the hard links are desired and were created by a package.


### PR DESCRIPTION
To properly share objects with ostree, /var/lib/flatpak is a symlink to
/sysroot/flatpak. Since /sysroot will become /, point the symlink to
/flatpak instead.

https://phabricator.endlessm.com/T12238