### PR TITLE
Add gvfs-bin to the Endless Runtime,

### DIFF
--- a/eos-platform-runtime-depends
+++ b/eos-platform-runtime-depends
@@ -24,6 +24,7 @@ gstreamer0.10-alsa
 gstreamer0.10-plugins-base
 gstreamer0.10-plugins-good
 gstreamer0.10-pulseaudio
+gvfs-bin
 kde-games-core-declarative
 kde-runtime
 kdeedu-kvtml-data


### PR DESCRIPTION
This is needed to supply gvfs-open (called by default by xdg-open on GNOME
system), in T12251 we use it for Dropbox, but it's probably usefull for
other apps.

https://phabricator.endlessm.com/T12251

Signed-off-by: Niv Sardi <xaiki@evilgiggle.com>