### PR TITLE
eos-launch-all: exclude EknServices

### DIFF
--- a/eos-tech-support/eos-launch-all
+++ b/eos-tech-support/eos-launch-all
@@ -19,7 +19,7 @@ do
     CORE_APPS+="$app "
 done
 
-FLATPAK_APPS=`flatpak list --app`
+FLATPAK_APPS=`flatpak list --app | grep -v EknServices`
 
 for app in $CORE_APPS $FLATPAK_APPS
 do


### PR DESCRIPTION
Although this is technically a flatpak "app", it is actually
just a helper and does not have an executable, so let's skip it.

https://phabricator.endlessm.com/T12824