### PR TITLE
Fix coredump generation for eos-convert-system-qa

### DIFF
--- a/eos-tech-support/eos-convert-system-qa
+++ b/eos-tech-support/eos-convert-system-qa
@@ -74,7 +74,7 @@ fi
 
 # Enable systemd coredumps storage
 echo "Enabling systemd coredumps processing and storage"
-echo "kernel.core_pattern=|/lib/systemd/systemd-coredump %p %u %g %s %t %e" > /etc/sysctl.d/50-coredump.conf
+echo "kernel.core_pattern=|/lib/systemd/systemd-coredump %p %u %g %s %t %c %e" > /etc/sysctl.d/50-coredump.conf
 
 # Set metrics env to dev.
 if $METRICS; then


### PR DESCRIPTION
Commit b2d1158a66365d3c2b6deda8423f54b136da12b8 fixed this for
eos-convert-system, but not for eos-convert-system-qa.