### PR TITLE
Move fonts package back to runtime

### DIFF
--- a/base-depends
+++ b/base-depends
@@ -6,6 +6,7 @@ eos-icon-theme
 fonts-droid
 fonts-lato
 fonts-liberation
+fonts-wqy-microhei
 gnome-themes-standard
 gstreamer1.0-libav
 gstreamer1.0-plugins-good

--- a/eos-core-depends
+++ b/eos-core-depends
@@ -50,7 +50,6 @@ fonts-arphic-uming
 fonts-crosextra-caladea
 fonts-crosextra-carlito
 fonts-farsiweb
-fonts-gargi
 fonts-indic
 fonts-kacst
 fonts-khmeros
@@ -63,11 +62,9 @@ fonts-sil-andika
 fonts-sil-gentium-basic
 fonts-sil-padauk
 fonts-thai-tlwg
-fonts-tlwg-waree
 fonts-unfonts-core
 fonts-uralic
 fonts-vlgothic
-fonts-wqy-microhei
 fonts-wqy-zenhei
 foomatic-db-compressed-ppds
 fprintd

--- a/eos-platform-runtime-depends
+++ b/eos-platform-runtime-depends
@@ -10,8 +10,10 @@ eos-knowledge-0-bin
 eos-sdk-webhelper
 fonts-dosis
 fonts-dustin
+fonts-gargi
 fonts-noto-cjk
 fonts-roboto
+fonts-tlwg-waree
 freeglut3
 gir1.2-clutter-1.0
 gir1.2-clutter-gst-2.0


### PR DESCRIPTION
Two of these are only needed for applications, so let's put them in the
runtime. The WQY font is used for Chinese, so let's share between both
runtime and core OS.

https://phabricator.endlessm.com/T13052