### PR TITLE
base-depends: add sound-theme-freedesktop

### DIFF
--- a/base-depends
+++ b/base-depends
@@ -29,5 +29,6 @@ locales
 lzma
 mawk
 netbase
+sound-theme-freedesktop
 ttf-freefont
 xdg-utils


### PR DESCRIPTION
This was lost at some point during the package reorganization.

https://phabricator.endlessm.com/T12866