### PR TITLE
core-depends: add showmehow service

### DIFF
--- a/eos-core-depends
+++ b/eos-core-depends
@@ -102,9 +102,11 @@ obexd-client
 openprinting-ppds
 openssh-server
 printer-driver-all
+python3-showmehow
 rhythmbox (>= 2.99.1)
 rtkit
 shotwell
+showmehow-service
 simple-scan
 smbclient
 system-config-printer-gnome


### PR DESCRIPTION
This is a necessary service for the Mission image. As its using the
same eos ostree, it needs to be added to the core-depends.

https://phabricator.endlessm.com/T13178