### PR TITLE
Use /proc/sys/kernel/secure_boot instead of EFI vars to check for secure boot

### DIFF
--- a/eos-tech-support/eos-check-secureboot
+++ b/eos-tech-support/eos-check-secureboot
@@ -1,9 +1,0 @@
-#!/usr/bin/python
-# Check if we are under secure boot by reading the correspondent EFI var
-
-EFIVARS = "/sys/firmware/efi/vars"
-SECUREBOOT ="SecureBoot-8be4df61-93ca-11d2-aa0d-00e098032b8c"
-
-f = open(EFIVARS + "/" + SECUREBOOT + "/data", "rb");
-secure_boot = ord(f.read(1))
-exit(secure_boot)

--- a/eos-tech-support/eos-check-secureboot
+++ b/eos-tech-support/eos-check-secureboot
@@ -4,9 +4,6 @@
 EFIVARS = "/sys/firmware/efi/vars"
 SECUREBOOT ="SecureBoot-8be4df61-93ca-11d2-aa0d-00e098032b8c"
 
-try:
-    f = open(EFIVARS + "/" + SECUREBOOT + "/data", "rb");
-except IOError:
-    exit(0)
+f = open(EFIVARS + "/" + SECUREBOOT + "/data", "rb");
 secure_boot = ord(f.read(1))
 exit(secure_boot)

--- a/eos-tech-support/eos-convert-system
+++ b/eos-tech-support/eos-convert-system
@@ -5,11 +5,6 @@ if [ ! -L /ostree ]; then
   exit 1
 fi
 
-if ! eos-check-secureboot; then
-  echo "Error: Secure boot needs to be disabled before running $0" >&2
-  exit 1
-fi
-
 # Set the metrics system to use the dev environment
 echo "Configuring Metrics System for Dev"
 source eos-select-metrics-env 'dev'

--- a/eos-tech-support/eos-convert-system
+++ b/eos-tech-support/eos-convert-system
@@ -5,6 +5,12 @@ if [ ! -L /ostree ]; then
   exit 1
 fi
 
+SECURE_BOOT_FILE=/proc/sys/kernel/secure_boot
+if [ -e ${SECURE_BOOT_FILE} ] && [ $(cat ${SECURE_BOOT_FILE}) -eq 1 ]; then
+  echo "Error: Secure boot needs to be disabled before running $0" >&2
+  exit 1
+fi
+
 # Set the metrics system to use the dev environment
 echo "Configuring Metrics System for Dev"
 source eos-select-metrics-env 'dev'


### PR DESCRIPTION
For some reason (apparently a firmware problem, since a BIOS update for the Brix fixes this) the SecureBoot EFI var is not exported to userspace on the Mission. Ubuntu exports this information in `/proc`, so we can use it instead and get rid of `eos-check-secureboot` altogether.

https://phabricator.endlessm.com/T13009