### PR TITLE
Add openjdk-7-jdk to the SDK metapackage

### DIFF
--- a/eos-sdk-runtime-depends
+++ b/eos-sdk-runtime-depends
@@ -31,6 +31,7 @@ libjson-glib-dev
 libsoup2.4-dev
 libwebkit2gtk-4.0-dev
 make
+openjdk-7-jdk
 patchutils
 quilt
 ruby-compass


### PR DESCRIPTION
Provided that the runtime metapackage contains the corresponding JRE package (`openjdk-7-jre`), it just seems fitting to add this to the SDK.

https://phabricator.endlessm.com/T13393