### PR TITLE
eos-diagnostics: add sys_vendor value

### DIFF
--- a/eos-tech-support/eos-diagnostics
+++ b/eos-tech-support/eos-diagnostics
@@ -28,7 +28,8 @@ function collectGraphicsRenderer() {
 }
 
 function collectBoardInfo() {
-    let table = { 'Product name': '/sys/devices/virtual/dmi/id/product_name',
+    let table = { 'System vendor': '/sys/devices/virtual/dmi/id/sys_vendor',
+		  'Product name': '/sys/devices/virtual/dmi/id/product_name',
 		  'Product serial': '/sys/devices/virtual/dmi/id/product_uuid',
 		  'Product version': '/sys/devices/virtual/dmi/id/product_version',
 		  'Board vendor': '/sys/devices/virtual/dmi/id/board_vendor',


### PR DESCRIPTION
For code that uses DMI info to match specific systems, the most common
fields used are sys_vendor and product_name together.

sys_vendor was not being reported here, add it.

@cosimoc can you take a quick look?