### PR TITLE
eos-diagnostics: include codecs info

### DIFF
--- a/eos-tech-support/eos-diagnostics
+++ b/eos-tech-support/eos-diagnostics
@@ -293,6 +293,16 @@ function dumpDiagnostics(filename) {
     fullDump += collectChromiumPluginsInfo();
     fullDump += '\n';
 
+    fullDump += '======================\n'
+    fullDump += '= Codecs information =\n'
+    fullDump += '======================\n'
+    fullDump += '\n';
+    fullDump += trySpawn('find /var/lib/codecs');
+    fullDump += '\n';
+    fullDump += trySpawn('gst-inspect-1.0 libav');
+    fullDump += trySpawn('gst-inspect-1.0 -b');
+    fullDump += '\n';
+
     fullDump += '================================\n'
     fullDump += '= Flatpak remote configuration =\n'
     fullDump += '================================\n'


### PR DESCRIPTION
By listing the contents of /var/lib/codecs, we can easily see
which keys are installed and which codecs have been decrypted.

https://phabricator.endlessm.com/T13401