### PR TITLE
Add cmake to the SDK runtime

### DIFF
--- a/eos-sdk-runtime-depends
+++ b/eos-sdk-runtime-depends
@@ -3,6 +3,7 @@ autoconf
 automake
 bison
 build-essential
+cmake
 diffutils
 eos-knowledge-0-dev
 eos-knowledge-db-build


### PR DESCRIPTION
We need it to build other projects when using Flatpak.

https://phabricator.endlessm.com/T13441