### PR TITLE
eos-diagnostics: add Endless image details

### DIFF
--- a/eos-tech-support/eos-diagnostics
+++ b/eos-tech-support/eos-diagnostics
@@ -192,6 +192,15 @@ function dumpDiagnostics(filename) {
     fullDump += tryReadFile('/etc/os-release');
     fullDump += '\n';
 
+    fullDump += '===================\n'
+    fullDump += '= EndlessOS image =\n'
+    fullDump += '===================\n'
+    fullDump += '\n';
+    fullDump += trySpawn('attr -q -g eos-image-version /sysroot');
+    fullDump += trySpawn('attr -q -g eos-image-version /');
+    fullDump += '\n';
+    fullDump += '\n';
+
     fullDump += '=========================\n'
     fullDump += '= EndlessOS personality =\n'
     fullDump += '=========================\n'


### PR DESCRIPTION
Note that we try to get the attributes for both '/sysroot' (for OSTree)
and '/' (for converted systems).  There is no line feed on the output,
so we just assume that one will silently fail and print nothing.

https://phabricator.endlessm.com/T13465