### PR TITLE
Stop including eos-chrome-plugin-updater-s3 in the base core image

### DIFF
--- a/eos-core-depends
+++ b/eos-core-depends
@@ -18,7 +18,6 @@ debconf-i18n
 eog
 eos-acknowledgements
 eos-chrome-plugin-updater
-eos-chrome-plugin-updater-s3 [armhf]
 eos-codecs-manager
 eos-event-recorder-daemon
 eos-exploration-center


### PR DESCRIPTION
From now on, eos-chrome-plugin-updater will be installed both on Intel
and ARM architectures, so there's no need for this differentiation.

https://phabricator.endlessm.com/T13597