### PR TITLE
eos-write-image: clarify usage message

### DIFF
--- a/eos-tech-support/eos-write-image
+++ b/eos-tech-support/eos-write-image
@@ -11,12 +11,12 @@ eval set -- "$ARGS"
 usage() {
     cat <<EOF
 Usage:
-   $0 image device [block_size]
-Where:
-   image = raw or zipped image file (.img or .img.gz)
-   device = device name (e.g., '/dev/sdb' or '/dev/mmcblk0')
-            or '-' to write uncompressed image to stdout
-   block_size = block size in bytes (default = '1M')
+   $0 [options] IMAGE DEVICE [BLOCK_SIZE]
+Arguments:
+   IMAGE        raw or zipped image file (.img or .img.gz)
+   DEVICE       device name (e.g., '/dev/sdb' or '/dev/mmcblk0')
+                or '-' to write uncompressed image to stdout
+   BLOCK_SIZE   block size in bytes (default = '1M')
 Options:
    -f,--force   don't ask to proceed with writing
    --sparse     use dd sparse conversion option
@@ -74,7 +74,12 @@ for command in "${!dependencies[@]}"; do
 done
 
 if [ $# -lt 2 ] ; then
-    echo "Missing command line arguments" >&2
+    if [ $# -eq 0 ]; then
+        echo "Error: missing IMAGE and DEVICE arguments" >&2
+    else
+        echo "Error: missing DEVICE arguments" >&2
+    fi
+    echo >&2
     usage >&2
     exit 1
 fi

--- a/eos-tech-support/eos-write-image
+++ b/eos-tech-support/eos-write-image
@@ -18,11 +18,11 @@ Where:
             or '-' to write uncompressed image to stdout
    block_size = block size in bytes (default = '1M')
 Options:
-   -f,--force	don't ask to proceed with writing
-   --sparse	use dd sparse conversion option
-   --debug	turn on debugging messages
-   --removable	device is removable (remove fallback.efi)
-   -h,--help	show this message
+   -f,--force   don't ask to proceed with writing
+   --sparse     use dd sparse conversion option
+   --debug      turn on debugging messages
+   --removable  device is removable (remove fallback.efi)
+   -h,--help    show this message
 EOF
 }
 
@@ -44,7 +44,7 @@ while true; do
             set -x
             shift
             ;;
-	--removable)
+        --removable)
             REMOVABLE=true
             shift
             ;;


### PR DESCRIPTION
A user reported trouble running this script. It appears they were not passing it any arguments; so let's make that error case a little more explicit.
