### PR TITLE
Add libwebp-dev to com.endlessm.Sdk

### DIFF
--- a/eos-sdk-runtime-depends
+++ b/eos-sdk-runtime-depends
@@ -36,6 +36,7 @@ libsecret-1-dev
 libsoup2.4-dev
 libsqlite3-dev
 libwebkit2gtk-4.0-dev
+libwebp-dev
 libxslt1-dev
 make
 openjdk-7-jdk


### PR DESCRIPTION
This is needed for building webkit for com.endlessm.programming.

https://phabricator.endlessm.com/T13157