### PR TITLE
eos-convert-system: Operate on the correct /var/lib/flatpak

### DIFF
--- a/eos-tech-support/eos-convert-system
+++ b/eos-tech-support/eos-convert-system
@@ -68,8 +68,8 @@ cp -paxl ${OSTREE_DEPLOY}/var /sysroot
 # To properly share objects with ostree, /var/lib/flatpak is a symlink
 # to /sysroot/flatpak. Since /sysroot will become /, point the symlink
 # to /flatpak instead.
-if [ "$(readlink -f /var/lib/flatpak)" = /sysroot/flatpak ]; then
-  ln -sfT /flatpak /var/lib/flatpak
+if [ "$(readlink -f /sysroot/var/lib/flatpak)" = /sysroot/flatpak ]; then
+  ln -sfT /flatpak /sysroot/var/lib/flatpak
 fi
 
 # Break any unwanted hard links. We assume that only empty files with


### PR DESCRIPTION
The /var/lib/flatpak symlink is changed after everything has been copied
to /sysroot. So, changing the running /var/lib/flatpak has no effect
after rebooting. Check and change the correct symlink in
/sysroot/var/lib/flatpak.

https://phabricator.endlessm.com/T13748