### PR TITLE
More com.endlessm.Sdk dependencies

### DIFF
--- a/eos-sdk-runtime-depends
+++ b/eos-sdk-runtime-depends
@@ -35,12 +35,15 @@ libjson-glib-dev
 libsecret-1-dev
 libsoup2.4-dev
 libsqlite3-dev
+libwebkit2gtk-3.0-dev
 libwebkit2gtk-4.0-dev
 libwebp-dev
 libxslt1-dev
 make
 openjdk-7-jdk
 patchutils
+python3-dbus
+python3-dbusmock
 quilt
 ruby-compass
 ruby-sass


### PR DESCRIPTION
These are still needed to build eos-metrics and eos-sdk in order to make
the custom version of eos-programming.

https://phabricator.endlessm.com/T13157