### PR TITLE
Include eos-installer in normal images

### DIFF
--- a/eos-core-depends
+++ b/eos-core-depends
@@ -22,6 +22,7 @@ eos-codecs-manager
 eos-event-recorder-daemon
 eos-exploration-center
 eos-gates
+eos-installer
 eos-kalite-system-helper
 eos-language-pack-ar
 eos-language-pack-bn

--- a/eos-installer-meta-depends
+++ b/eos-installer-meta-depends
@@ -4,4 +4,4 @@
 include base-depends
 include os-depends
 
-eos-installer
+eos-installer-standalone

--- a/eos-installer-meta-depends
+++ b/eos-installer-meta-depends
@@ -4,5 +4,4 @@
 include base-depends
 include os-depends
 
-eos-image-keyring
 eos-installer

--- a/eos-tech-support-depends
+++ b/eos-tech-support-depends
@@ -1,4 +1,5 @@
 bash-completion
+eos-image-keyring
 iw
 lshw
 pv


### PR DESCRIPTION
This depends on [corresponding packaging
changes](https://github.com/endlessm/eos-installer/pull/23) to split the parts
of eos-installer which conflict with gnome-initial-setup into a new package,
eos-installer-standalone.

https://phabricator.endlessm.com/T12548