### PR TITLE
eos-list-users / eos-reset-password: Update for eos3

### DIFF
--- a/eos-tech-support/eos-list-users
+++ b/eos-tech-support/eos-list-users
@@ -1,9 +1,6 @@
 #!/bin/bash -e
 
-# Lists all users (i.e., all home directories on /dev/sda2)
-
-DEVICE=/dev/sda2
-MOUNT=/mnt/sda2
+# Lists all users (i.e., all home directories on all ostree devices)
 
 USERID=$(id -u)
 if [ "$USERID" != "0" ]; then
@@ -11,17 +8,34 @@ if [ "$USERID" != "0" ]; then
     exit 1
 fi
 
+MOUNT=`mktemp -d`
+
 cleanup() {
     set +e
-    umount $MOUNT
+    if mount | grep $MOUNT; then
+        umount $MOUNT
+    fi
     rmdir $MOUNT
 }
 trap cleanup EXIT
 
 mkdir -p $MOUNT
-mount $DEVICE $MOUNT
 
-# FIXME A more robust approach would be the following:
-# - read /usr/etc/login.defs and extract UID_MIN
-# - read /etc/passwd and get all users with uid >= UID_MIN
-ls $MOUNT/home
+DEVICES=`blkid -t LABEL=ostree | awk -F ":" '{print $1}'`
+
+echo
+
+for DEVICE in $DEVICES
+do
+    mount $DEVICE $MOUNT
+
+    # FIXME A more robust approach would be the following:
+    # - read /usr/etc/login.defs and extract UID_MIN
+    # - read /etc/passwd and get all users with uid >= UID_MIN
+    echo Users on $DEVICE:
+    ls $MOUNT/home
+    echo
+
+    umount $MOUNT
+done
+

--- a/eos-tech-support/eos-reset-password
+++ b/eos-tech-support/eos-reset-password
@@ -4,15 +4,13 @@
 # Except for the special shared account,
 # the user will be asked for a password on next login
 
-BOOTDEV=/dev/sda1
-DEVICE=/dev/sda2
-MOUNT=/mnt/sda2
-
-if [ -z "$1" ]; then
-    echo usage: $0 username
+if [ "$#" -ne 2 ]; then
+    echo "usage: $0 device username"
+    echo "(run eos-list-users to see a list of devices and usernames)"
     exit
 fi
-USERNAME=$1
+DEVICE=$1
+USERNAME=$2
 
 USERID=$(id -u)
 if [ "$USERID" != "0" ]; then
@@ -32,16 +30,14 @@ else
     DATE=0
 fi
 
+MOUNT=`mktemp -d`
+
 cleanup() {
     set +e
-    umount $MOUNT/boot
     umount $MOUNT
     rmdir $MOUNT
 }
 trap cleanup EXIT
 
-mkdir -p $MOUNT
 mount $DEVICE $MOUNT
-mount $BOOTDEV $MOUNT/boot
-CURRENT=$(ostree admin --sysroot=$MOUNT --print-current-dir)
-sed -i "s/$USERNAME:[^:]*:[^:]*:/$USERNAME::$DATE:/" $CURRENT/etc/shadow
+sed -i "s/$USERNAME:[^:]*:[^:]*:/$USERNAME::$DATE:/" $MOUNT/etc/shadow


### PR DESCRIPTION
The hard-coded /dev/sda2 is no longer valid for eos3.

Instead, let's list all users on all ostree devices,
and then require the user to explicitly specify the device
that contains the user whose password is to be reset.

With these changes, we now support split disks, too.

https://phabricator.endlessm.com/T6324