### PR TITLE
Revert "eos-convert-system: Check if we're running under secure boot"

### DIFF
--- a/eos-tech-support/eos-convert-system
+++ b/eos-tech-support/eos-convert-system
@@ -5,12 +5,6 @@ if [ ! -L /ostree ]; then
   exit 1
 fi
 
-SECURE_BOOT_FILE=/proc/sys/kernel/secure_boot
-if [ -e ${SECURE_BOOT_FILE} ] && [ $(cat ${SECURE_BOOT_FILE}) -eq 1 ]; then
-  echo "Error: Secure boot needs to be disabled before running $0" >&2
-  exit 1
-fi
-
 # Set the metrics system to use the dev environment
 echo "Configuring Metrics System for Dev"
 source eos-select-metrics-env 'dev'


### PR DESCRIPTION
This reverts commit cab6e9bfb678f888f0e989df4c21023b39227e35.

Now that we are producing packages for signed kernels and bootloader, it
is possible to have a converted system under secure boot.

https://phabricator.endlessm.com/T13811