### PR TITLE
eos-convert-system: drop /endless

### DIFF
--- a/eos-tech-support/eos-convert-system
+++ b/eos-tech-support/eos-convert-system
@@ -43,7 +43,7 @@ echo "Updating HOME directory"
 sed -i "s#/sysroot/home#/home#g" /etc/passwd* /etc/adduser.conf /etc/default/useradd
 
 # Directories in the deployment root to merge to /sysroot
-ROOT_DIRS=(bin etc lib sbin usr opt var endless)
+ROOT_DIRS=(bin etc lib sbin usr opt var)
 if [ -d ${OSTREE_DEPLOY_CURRENT}/lib64 ]; then
   ROOT_DIRS+=(lib64)
 fi


### PR DESCRIPTION
This directory is vestigial in 3.0.x ostrees, and no longer exists in
3.1.x ostrees; so trying to merge it to /sysroot/endless is guaranteed
to fail.

https://phabricator.endlessm.com/T13832