### PR TITLE
eos-core: Include strace

### DIFF
--- a/eos-core-depends
+++ b/eos-core-depends
@@ -109,6 +109,7 @@ shotwell
 showmehow-service
 simple-scan
 smbclient
+strace
 system-config-printer-gnome
 systemd-coredump
 totem


### PR DESCRIPTION
This is an invaluable debugging tool and is only roughly 350 kB. We
already include gdb in eos-core, which is quite a bit bigger. It
probably makes sense to put them both in os-depends so that they're
available everywhere, but this is good enough for now.

https://phabricator.endlessm.com/T14123