### PR TITLE
os: Include support for flatpak python GIR bindings

### DIFF
--- a/os-depends
+++ b/os-depends
@@ -26,6 +26,7 @@ file
 fonts-dejavu
 geoclue-2.0
 gettext-base
+gir1.2-flatpak-1.0
 gir1.2-ostree-1.0
 gnome-session
 gnupg
@@ -58,6 +59,8 @@ ostree
 p7zip-full
 parted
 policykit-1
+python-gi
+python3-gi
 pulseaudio
 pulseaudio-module-bluetooth
 pulseaudio-module-x11


### PR DESCRIPTION
Initially this will used be in the image builder so that it can
intelligently query flatpak instead of scraping the CLI output. However,
I can also see it being useful for providing flatpak support scripts in
the future. E.g., to change the default branch when upgrading from eos3
to eos4.

Only the python3-gi support is currently needed for the image builder,
and it's already pulled into eos-core. However, the OS already includes
both python 2 and python 3. The GI support packages are less than 1 MB,
so it seems nice to be able to use GIR from whichever python version is
preferred.

https://phabricator.endlessm.com/T14224