### PR TITLE
eos-diagnostics: dump CPU info

### DIFF
--- a/eos-tech-support/eos-diagnostics
+++ b/eos-tech-support/eos-diagnostics
@@ -432,6 +432,11 @@ let diagnostics = [
         content: function() { return collectBoardInfo(); },
     },
     {
+        title: 'CPU',
+        hardwareInfo: true,
+        content: function() { return tryReadFile('/proc/cpuinfo'); },
+    },
+    {
         title: 'Memory',
         hardwareInfo: true,
         content: function() {


### PR DESCRIPTION
Add CPU information to the regular and hardware dumps.

@cosimoc can you review this please? should be ultra quick