### PR TITLE
eos-reset-password: fix for ostree systems

### DIFF
--- a/eos-tech-support/eos-reset-password
+++ b/eos-tech-support/eos-reset-password
@@ -40,4 +40,5 @@ cleanup() {
 trap cleanup EXIT
 
 mount $DEVICE $MOUNT
-sed -i "s/$USERNAME:[^:]*:[^:]*:/$USERNAME::$DATE:/" $MOUNT/etc/shadow
+CURRENT=$(ostree admin --sysroot=$MOUNT --print-current-dir)
+sed -i "s/$USERNAME:[^:]*:[^:]*:/$USERNAME::$DATE:/" $CURRENT/etc/shadow


### PR DESCRIPTION
Somehow I must have inadvertantly tested on a non-ostree system
when I cleaned up for eos3 / split disk support, as the script
is broken when assuming that /etc is available directly under
the mount point.  Instead, bring back the logic that used ostree
admin to find the currently deployed directory.

https://phabricator.endlessm.com/T14303