### PR TITLE
eos-{list-users,reset-password}: support dual-boot installations

### DIFF
--- a/eos-tech-support/eos-list-users
+++ b/eos-tech-support/eos-list-users
@@ -9,33 +9,78 @@ if [ "$USERID" != "0" ]; then
 fi
 
 MOUNT=`mktemp -d`
+LOOPBACK=
 
 cleanup() {
     set +e
-    if mount | grep $MOUNT; then
-        umount $MOUNT
+    if mount | grep --quiet $MOUNT; then
+        umount "$MOUNT"
+
+        if [ -n "$LOOPBACK" ]; then
+            losetup -d "$LOOPBACK"
+            udevadm settle
+
+            umount "$MOUNT"
+        fi
     fi
     rmdir $MOUNT
 }
 trap cleanup EXIT
 
-mkdir -p $MOUNT
+list_users() {
+    local DEVICE=$1
+    local PHYSICAL_DEVICE=$2
 
-DEVICES=`blkid -t LABEL=ostree | awk -F ":" '{print $1}'`
-
-echo
-
-for DEVICE in $DEVICES
-do
     mount $DEVICE $MOUNT
 
     # FIXME A more robust approach would be the following:
     # - read /usr/etc/login.defs and extract UID_MIN
     # - read /etc/passwd and get all users with uid >= UID_MIN
-    echo Users on $DEVICE:
+    echo Users on $PHYSICAL_DEVICE:
     ls $MOUNT/home
     echo
 
     umount $MOUNT
-done
+}
 
+list_dualboot_users() {
+    local PHYSICAL_DEVICE=${1:?}
+
+    mount $NAME $MOUNT
+    local ENDLESS_IMG="$MOUNT/endless/endless.img"
+
+    if [ -e "$ENDLESS_IMG" ] && [ ! -e "$MOUNT/endless/live" ]; then
+        # Time for a loopback mount!
+        LOOPBACK=$(losetup --find --show "$ENDLESS_IMG")
+        partprobe "$LOOPBACK"
+
+        # Find the ostree partition
+        local DEVICE=$(lsblk --raw --paths -o LABEL,NAME "$LOOPBACK" |
+                 awk '/^ostree / { print $2 }')
+        if [ -z "$DEVICE" ]; then
+            echo "Cannot find ostree partition in $ENDLESS_IMG on $PHYSICAL_DEVICE" >&2
+            exit 1
+        fi
+
+        list_users $DEVICE $PHYSICAL_DEVICE
+        losetup -d "$LOOPBACK"
+        LOOPBACK=
+    fi
+
+    umount $MOUNT
+}
+
+# Basic Data partition types for MBR and GPT partition tables
+BD_MBR="0x7"
+BD_GPT="EBD0A0A2-B9E5-4433-87C0-68B6B72699C7"
+
+echo
+DEVICES=$(lsblk --raw --paths --noheadings -o NAME,PARTTYPE,LABEL)
+while read NAME PARTTYPE LABEL; do
+    if [ "${LABEL}" == "ostree" ]; then
+        list_users $NAME $NAME
+    elif [ "${PARTTYPE}" == "${BD_MBR}" ] || \
+         [ "${PARTTYPE^^}" == "${BD_GPT}" ]; then
+        list_dualboot_users $NAME
+    fi
+done <<< "$DEVICES"

--- a/eos-tech-support/eos-reset-password
+++ b/eos-tech-support/eos-reset-password
@@ -7,7 +7,7 @@
 if [ "$#" -ne 2 ]; then
     echo "usage: $0 device username"
     echo "(run eos-list-users to see a list of devices and usernames)"
-    exit
+    exit 1
 fi
 DEVICE=$1
 USERNAME=$2
@@ -20,7 +20,7 @@ fi
 
 if [ $USERNAME = root ]; then
     echo "Resetting root password not allowed"
-    exit
+    exit 1
 elif [ $USERNAME = shared ]; then
     # For the shared account, set the change date (days since Jan 1, 1970)
     # to today (so that user will not be asked to set a password)

--- a/eos-tech-support/eos-reset-password
+++ b/eos-tech-support/eos-reset-password
@@ -31,14 +31,49 @@ else
 fi
 
 MOUNT=`mktemp -d`
+LOOPBACK=
 
 cleanup() {
     set +e
-    umount $MOUNT
-    rmdir $MOUNT
+
+    umount "$MOUNT"
+
+    if [ -n "$LOOPBACK" ]; then
+        losetup -d "$LOOPBACK"
+        udevadm settle
+
+        umount "$MOUNT"
+    fi
+
+    rmdir "$MOUNT"
 }
 trap cleanup EXIT
 
 mount $DEVICE $MOUNT
+
+# Check if it's a Windows partition with a dual-boot Endless OS image
+LABEL=$(lsblk -o LABEL --raw --nodeps --noheadings "$DEVICE")
+ENDLESS_IMG="$MOUNT/endless/endless.img"
+if [ "$LABEL" != "ostree" ] && [ -e "$ENDLESS_IMG" ]; then
+    if [ -e "$MOUNT/endless/live" ]; then
+        echo "$DEVICE is a read-only live USB; refusing to change passwords" >&2
+        exit 1
+    fi
+
+    # Time for a loopback mount!
+    LOOPBACK=$(losetup --find --show "$ENDLESS_IMG")
+    partprobe "$LOOPBACK"
+
+    # Find the ostree partition
+    DEVICE=$(lsblk --raw --paths -o LABEL,NAME "$LOOPBACK" |
+             awk '/^ostree / { print $2 }')
+    if [ -z "$DEVICE" ]; then
+        echo "Cannot find Endless OS partition in $ENDLESS_IMG" >&2
+        exit 1
+    fi
+
+    mount "$DEVICE" "$MOUNT"
+fi
+
 CURRENT=$(ostree admin --sysroot=$MOUNT --print-current-dir)
 sed -i "s/$USERNAME:[^:]*:[^:]*:/$USERNAME::$DATE:/" $CURRENT/etc/shadow

--- a/eos-tech-support/eos-uninstall-dualboot
+++ b/eos-tech-support/eos-uninstall-dualboot
@@ -10,7 +10,7 @@ eval set -- "$ARGS"
 usage() {
     cat <<EOF
 Usage:
-   $0 [--no-act] DEVICE
+   $0 [--gap] [--no-act] DEVICE
 
 Uninstalls GRUB from an Endless OS dual-boot machine, restoring the normal
 Windows boot setup.


### PR DESCRIPTION
I'm not particularly happy with the code duplication here. One option would be
to merge the two scripts (and preferably rewrite it in Python in the process --
I had some nasty scoping problems with the cleanup hooks).

https://phabricator.endlessm.com/T14302