### PR TITLE
eos-core-depends: stop using old virtual obexd-client

### DIFF
--- a/eos-core-depends
+++ b/eos-core-depends
@@ -101,7 +101,7 @@ ibus-unikey
 imagescan
 libreoffice
 nautilus
-obexd-client
+bluez-obexd
 openprinting-ppds
 openssh-server
 printer-driver-all


### PR DESCRIPTION
In bluez-5.25 this was provided by bluez-obexd and in the latest
version, that Provides has been removed. Switch to using the real
package name.

https://phabricator.endlessm.com/T14411