### PR TITLE
eos-convert-system: Enable coredump genation in sysroot

### DIFF
--- a/eos-tech-support/eos-convert-system
+++ b/eos-tech-support/eos-convert-system
@@ -94,7 +94,7 @@ mkdir -p /var/log/journal
 
 # Enable systemd coredumps storage
 echo "Enabling systemd coredumps processing and storage"
-echo "kernel.core_pattern=|/lib/systemd/systemd-coredump %p %u %g %s %t %c %e" > /etc/sysctl.d/50-coredump.conf
+echo "kernel.core_pattern=|/lib/systemd/systemd-coredump %p %u %g %s %t %c %e" > /sysroot/etc/sysctl.d/50-coredump.conf
 
 # Put the kernels/initramfs in the expected place by Debian
 cp -pax ${OSTREE_DEPLOY_CURRENT}/boot/{vmlinuz,initramfs}*  /boot


### PR DESCRIPTION
We are generating /etc/sysctl.d/50-coredump.conf in the OSTree
deployment instead of the root partition's root, so it has no effect in
converted system after reboot. This points it directly to /sysroot.

https://phabricator.endlessm.com/T14497