### PR TITLE
Add coding-shell-extensions to the image

### DIFF
--- a/eos-core-depends
+++ b/eos-core-depends
@@ -15,6 +15,7 @@ cheese
 chromium-browser
 coding-chatbox
 coding-game-manager
+coding-shell-extensions
 cups
 debconf-i18n
 eog


### PR DESCRIPTION
For the coding project we have packages a set of shell extensions that should be integrated into the image.