### PR TITLE
Coding, CodeView: needs flatpak-builder to be present

### DIFF
--- a/eos-core-depends
+++ b/eos-core-depends
@@ -48,6 +48,7 @@ evince
 evolution
 file-roller
 flatpak
+flatpak-builder
 fonts-arabeyes
 fonts-arphic-ukai
 fonts-arphic-uming


### PR DESCRIPTION
GNOME Builder will not be able to build flatpaks, this is needed by the CodeView feature.