### PR TITLE
Fix typo in echo statement in eos-convert-system-qa

### DIFF
--- a/eos-tech-support/eos-convert-system-qa
+++ b/eos-tech-support/eos-convert-system-qa
@@ -104,7 +104,7 @@ if $OSTREE || $APPS; then
         apps_repo=${apps_url##*/}
         new_apps_url="https://${OSTREE_USER}:${OSTREE_PASSWORD}@${OSTREE_HOST}/${OSTREE_DEV_ROOT}/${apps_repo}"
 
-        echo "Setting flatpak apps URL to $new_runtime_url"
+        echo "Setting flatpak apps URL to $new_apps_url"
         flatpak remote-modify eos-apps --url="$new_apps_url"
     fi
 


### PR DESCRIPTION
Probabaly the result of overly enthusiastic copy-pasting.