### PR TITLE
Get repo urls from ostree call, rather than from awk parsing

### DIFF
--- a/eos-tech-support/eos-convert-system-qa
+++ b/eos-tech-support/eos-convert-system-qa
@@ -93,14 +93,20 @@ if $OSTREE || $APPS; then
 
     # Change the Flatpak runtime and apps server URLs.
     if $APPS; then
-        runtime_url=$(flatpak remote-list -d | awk '/^eos-runtimes/{print $3}')
+        if [ -d /var/endless-extra/flatpak/repo ];
+            flatpak_repo=/var/endless-extra/flatpak/repo
+        else
+            flatpak_repo=/var/lib/flatpak/repo
+        fi
+
+        runtime_url=$(ostree --repo="$flatpak_repo" config get 'remote "eos-runtimes".url')
         runtime_repo=${runtime_url##*/}
         new_runtime_url="https://${OSTREE_USER}:${OSTREE_PASSWORD}@${OSTREE_HOST}/${OSTREE_DEV_ROOT}/${runtime_repo}"
 
         echo "Setting flatpak runtimes URL to $new_runtime_url"
         flatpak remote-modify eos-runtimes --url="$new_runtime_url"
 
-        apps_url=$(flatpak remote-list -d | awk '/^eos-apps/{print $3}')
+        apps_url=$(ostree --repo="$flatpak_repo" config get 'remote "eos-apps".url')
         apps_repo=${apps_url##*/}
         new_apps_url="https://${OSTREE_USER}:${OSTREE_PASSWORD}@${OSTREE_HOST}/${OSTREE_DEV_ROOT}/${apps_repo}"
 


### PR DESCRIPTION
The awk command was incorrect because there are an arbitrary number
of words in between the repo name and the url, so trying to extract
the url from that line was giving us incorrect results. Instead
let's just hardcode the repo names since they aren't going to change
anytime soon.