### PR TITLE
core: add telepathy packages

### DIFF
--- a/eos-core-depends
+++ b/eos-core-depends
@@ -117,6 +117,9 @@ smbclient
 strace
 system-config-printer-gnome
 systemd-coredump
+telepathy-idle
+telepathy-logger
+telepathy-mission-control-5
 totem
 tracker
 ttf-ancient-fonts


### PR DESCRIPTION
The Telepathy packages were removed in the past because
Empathy itself wasn't very used. With the upcoming GNOME
repositories enabled by default, however, Polari will
require Telepathy - and will fail without absolutely
no error message if Telepathy isn't there.

To make Polari work properly and avoid further frustrations,
add Telepathy (but not Empathy) back.

https://phabricator.endlessm.com/T14703