### PR TITLE
eos-write-live-image: Fix boolean check

### DIFF
--- a/eos-tech-support/eos-write-live-image
+++ b/eos-tech-support/eos-write-live-image
@@ -107,9 +107,6 @@ while true; do
         -i|--iso)
             shift
             ISO=true
-            MBR=false
-            NTFS=false
-            WRITABLE=false
             ;;
         -f|--force)
             shift


### PR DESCRIPTION
'true' and 'false' are not bash built-ins.

Signed-off-by: Carlo Caione <carlo@endlessm.com>