### PR TITLE
os: Remove pulseaudio-module-x11

### DIFF
--- a/os-depends
+++ b/os-depends
@@ -63,7 +63,6 @@ python-gi
 python3-gi
 pulseaudio
 pulseaudio-module-bluetooth
-pulseaudio-module-x11
 shim-efi-image-signed [amd64]
 spice-vdagent
 sudo


### PR DESCRIPTION
This package has been merged into the main pulseaudio package.

https://phabricator.endlessm.com/T14580