### PR TITLE
eos-platform-runtime-depends: added mali drivers dep

### DIFF
--- a/eos-platform-runtime-depends
+++ b/eos-platform-runtime-depends
@@ -34,6 +34,7 @@ kde-games-core-declarative
 kde-runtime
 kdeedu-kvtml-data
 khelpcenter4
+mali400-drivers-meson8 [armhf]
 libalut0
 libasound2
 libatkmm-1.6-1


### PR DESCRIPTION
Added mali dependency on flatpak runtime

https://phabricator.endlessm.com/T15102