### PR TITLE
allow eos-write-live-installer to be used by FNDE

### DIFF
--- a/eos-tech-support/eos-download-image
+++ b/eos-tech-support/eos-download-image
@@ -94,6 +94,10 @@ def main():
                    help='Fetch images from the Endless internal network')
 
     args = p.parse_args()
+
+    if args.product == 'fnde' and args.personality == 'base':
+        args.personality = 'fnde_aluno'
+
     base = INTERNAL_BASE_URL if args.internal else PUBLIC_BASE_URL
 
     if args.windows_tool:

--- a/eos-tech-support/eos-write-live-image
+++ b/eos-tech-support/eos-write-live-image
@@ -19,7 +19,7 @@ if [ ! -f $EOS_DOWNLOAD_IMAGE ]; then
     EOS_DOWNLOAD_IMAGE='eos-download-image'
 fi
 
-ARGS=$(getopt -o o:x:lnmwifh -l "os-image:,windows-tool:,latest,ntfs,mbr,writable,iso,force,help" -n "$0" -- "$@")
+ARGS=$(getopt -o o:x:lp:r:nmwifh -l "os-image:,windows-tool:,latest,personality:,product:,ntfs,mbr,writable,iso,force,help" -n "$0" -- "$@")
 eval set -- "$ARGS"
 
 usage() {
@@ -34,6 +34,8 @@ Options:
    -o,--os-image PATH      Path to Endless OS image
    -x,--windows-tool PATH  Path to Endless OS installer tool for Windows
    -l,--latest             Fetch latest OS image and/or Windows tool
+   -p,--personality        Fetch a different personality (default: base)
+   -r,--product            Fetch a different product (default: eos)
    -w,--writable           Allow image to be modified when run (which
                            prevents installing it later)
    -i,--iso                Write an ISO image
@@ -76,6 +78,8 @@ MBR=
 ISO=
 WRITABLE=
 FORCE=
+PERSONALITY=base
+PRODUCT=eos
 while true; do
     case "$1" in
         -o|--os-image)
@@ -91,6 +95,16 @@ while true; do
         -l|--latest)
             shift
             FETCH_LATEST=true
+            ;;
+        -p|--personality)
+            shift
+            PERSONALITY="$1"
+            shift
+            ;;
+        -r|--product)
+            shift
+            PRODUCT="$1"
+            shift
             ;;
         -n|--ntfs)
             shift
@@ -214,7 +228,7 @@ fi
 
 if [ ! -z "$FETCH_LATEST" ]; then
     if [ -z "$OS_IMAGE" ]; then
-        OS_IMAGE=$($EOS_DOWNLOAD_IMAGE --product eos)
+        OS_IMAGE=$($EOS_DOWNLOAD_IMAGE --personality "${PERSONALITY}" --product "${PRODUCT}")
     fi
     if [ -z "$WINDOWS_TOOL" ]; then
         WINDOWS_TOOL=$($EOS_DOWNLOAD_IMAGE --windows-tool)


### PR DESCRIPTION
Add --personality and --product arguments to eos-write-live-installer, and make eos-download-image select the fnde_aluno personality (rather than base, which doesn't exist) if the fnde product is requested.

https://phabricator.endlessm.com/T15135