### PR TITLE
eos-download-image: handle python <3.3 by making shlex.quote use optional

### DIFF
--- a/eos-tech-support/eos-download-image
+++ b/eos-tech-support/eos-download-image
@@ -25,7 +25,11 @@ def log(*args):
 
 
 def check_call(*args):
-    log('$ ' + ' '.join(map(shlex.quote, args)))
+    if hasattr(shlex, 'quote'):
+        qargs = map(shlex.quote, args)
+    else:
+        qargs = args
+    log('$ ' + ' '.join(qargs))
     subprocess.check_call(args, stdout=sys.stderr)
 
 


### PR DESCRIPTION
Fix running the eos-download-image script on older distros.

https://phabricator.endlessm.com/T15135