### PR TITLE
eos-sdk-runtime: Include appstream-compose

### DIFF
--- a/eos-sdk-runtime-depends
+++ b/eos-sdk-runtime-depends
@@ -1,4 +1,5 @@
 # Metapackage for the SDK runtime
+appstream-util
 autoconf
 automake
 bison


### PR DESCRIPTION
flatpak-builder tries to run appstream-compose in the sandbox when
finishing apps. Include appstream-util in eos-sdk-runtime so that
com.endlessm.Sdk has appstream-compose.

https://phabricator.endlessm.com/T14935