### PR TITLE
write-[live-]image: error if too many arguments given

### DIFF
--- a/eos-tech-support/eos-write-image
+++ b/eos-tech-support/eos-write-image
@@ -74,11 +74,13 @@ for command in "${!dependencies[@]}"; do
     fi
 done
 
-if [ $# -lt 2 ] ; then
+if [ $# -lt 2 ] || [ $# -gt 3 ] ; then
     if [ $# -eq 0 ]; then
         echo "Error: missing IMAGE and DEVICE arguments" >&2
+    elif [ $# -eq 1 ]; then
+        echo "Error: missing DEVICE argument" >&2
     else
-        echo "Error: missing DEVICE arguments" >&2
+        echo "Error: extra arguments after IMAGE DEVICE BLOCK_SIZE" >&2
     fi
     echo >&2
     usage >&2
@@ -148,8 +150,13 @@ if [ "$DEVICE" == "-" ]; then
     fi
     cat_image
 else
+    if [ ! -e "$DEVICE" ]; then
+        echo "$DEVICE does not exist... aborting!" >&2
+        exit 1
+    fi
+
     if [ ! -b "$DEVICE" ]; then
-        echo "$DEVICE not found or is not a block device" >&2
+        echo "$DEVICE is not a block device... aborting!" >&2
         exit 1
     fi
 

--- a/eos-tech-support/eos-write-live-image
+++ b/eos-tech-support/eos-write-live-image
@@ -25,9 +25,13 @@ ARGS=$(getopt -o o:x:lp:r:nmwiL:fh \
 eval set -- "$ARGS"
 
 usage() {
+    local SELF="$(basename "$0")"
     cat <<EOF
 Usage:
-   $0 [options] OUTPUT
+    $SELF [options] OUTPUT
+
+    # equivalent to $SELF --latest --os-image IMAGE OUTPUT
+    $SELF IMAGE OUTPUT
 
 Arguments:
     OUTPUT                 Device path (e.g. '/dev/sdb') or ISO image
@@ -152,6 +156,13 @@ while true; do
             ;;
     esac
 done
+
+# Be consistent with eos-write-image IMAGE DEVICE
+if [ $# -eq 2 ] && [ -z "$OS_IMAGE" ]; then
+    OS_IMAGE="$1"
+    FETCH_LATEST=true
+    shift
+fi
 
 if [ $# -ne 1 ] ; then
     if [ $# -lt 1 ] ; then

--- a/eos-tech-support/eos-write-live-image
+++ b/eos-tech-support/eos-write-live-image
@@ -153,8 +153,13 @@ while true; do
     esac
 done
 
-if [ $# -lt 1 ] ; then
-    echo "Missing OUTPUT" >&2
+if [ $# -ne 1 ] ; then
+    if [ $# -lt 1 ] ; then
+        echo "Error: missing OUTPUT" >&2
+    else
+        echo "Error: extra arguments after OUTPUT" >&2
+    fi
+    echo >&2
     usage >&2
     exit 1
 fi
@@ -214,8 +219,13 @@ if [ "$ISO" ]; then
     OUTPUT_DIR=$(dirname "$OUTPUT")
     mkdir -p "$OUTPUT_DIR"  &>/dev/null
 else
+    if [ ! -e "$OUTPUT" ]; then
+        echo "$OUTPUT does not exist... aborting!" >&2
+        exit 1
+    fi
+
     if [ ! -b "$OUTPUT" ]; then
-        echo "$OUTPUT does not exist or is not a block device... aborting!" >&2
+        echo "$OUTPUT is not a block device... aborting!" >&2
         exit 1
     fi
 

--- a/eos-tech-support/eos-write-live-image
+++ b/eos-tech-support/eos-write-live-image
@@ -221,6 +221,21 @@ for command in "${!dependencies[@]}"; do
     fi
 done
 
+if [ -z "$FETCH_LATEST" ]; then
+    if [ -z "$WINDOWS_TOOL" ] || [ -z "$OS_IMAGE" ]; then
+        echo "--os-image and --windows-tool are required if --latest is not specified" >&2
+        usage >&2
+        exit 2
+    fi
+fi
+
+echo "Summary:"
+echo
+echo "       Endless OS image: ${OS_IMAGE:-latest $PRODUCT $PERSONALITY image}"
+echo "  Installer for Windows: ${WINDOWS_TOOL:-latest release}"
+echo "                 Target: ${OUTPUT}"
+echo
+
 if [ "$ISO" ]; then
     if [ -f "$OUTPUT" ] && [ ! "$FORCE" ]; then
         echo "$OUTPUT already exists... aborting!" >&2
@@ -252,14 +267,6 @@ else
         if [[ ! "$response" =~ ^(yes|y)$ ]]; then
             exit 1
         fi
-    fi
-fi
-
-if [ -z "$FETCH_LATEST" ]; then
-    if [ -z "$WINDOWS_TOOL" ] || [ -z "$OS_IMAGE" ]; then
-        echo "--os-image and --windows-tool are required if --latest is not specified" >&2
-        usage >&2
-        exit 2
     fi
 fi
 


### PR DESCRIPTION
Lots of people assume you can call these the same way:

    eos-write-image IMAGE DEVICE
    eos-write-live-image IMAGE DEVICE

but the latter is wrong, and gives this confusing error:

    $OUTPUT does not exist or is not a block device... aborting!

The correct syntax is more like:

    eos-write-live-image DEVICE --os-image IMAGE --latest

In both cases, let's check the arguments more strictly and give better
error messages.

https://phabricator.endlessm.com/T15285