### PR TITLE
remove . from permitted strings in ISO volume ID

### DIFF
--- a/eos-tech-support/eos-write-live-image
+++ b/eos-tech-support/eos-write-live-image
@@ -403,7 +403,7 @@ if [ "$ISO" ]; then
     # Unzip the ISO bootzip content
     unzip -q -d "${DIR_IMAGES_ENDLESS}/grub/i386-pc/" "${BOOT_ZIP}" "iso/*"
 
-    VOLID=$(echo -n "$LABEL" | tr -cs '[A-Za-z0-9_.]' '-')
+    VOLID=$(echo -n "$LABEL" | tr -cs '[A-Za-z0-9_]' '-')
 
     # Generate the ISO image.
     # Parameters found using https://dev.lovelyhq.com/libburnia/libisoburn/raw/master/frontend/grub-mkrescue-sed.sh


### PR DESCRIPTION
Removes "-volid text does not comply to ISO 9660 / ECMA 119 rules" error
from xorisso and should improve compatibility.

https://phabricator.endlessm.com/T14986