### PR TITLE
eos-write-live-image: optimisation for uncompressed .img source file

### DIFF
--- a/eos-tech-support/eos-write-live-image
+++ b/eos-tech-support/eos-write-live-image
@@ -380,7 +380,15 @@ AUTORUN_INF
     fi
 fi
 
-"$EOS_WRITE_IMAGE" "$OS_IMAGE" "-" > "${DIR_IMAGES_ENDLESS}/endless.img"
+# attempt to avoid copy if input image is already compressed but fall back
+# gracefully if the image and tmpdir turn out to be different devices
+if [ "$OS_IMAGE" == "$OS_IMAGE_UNCOMPRESSED" ]; then
+    ln "$OS_IMAGE" "${DIR_IMAGES_ENDLESS}/endless.img" 2>/dev/null || true
+fi
+
+if [ ! -e "${DIR_IMAGES_ENDLESS}/endless.img" ]; then
+    "$EOS_WRITE_IMAGE" "$OS_IMAGE" "-" > "${DIR_IMAGES_ENDLESS}/endless.img"
+fi
 
 echo
 echo "Finalizing image"


### PR DESCRIPTION
If we are making an ISO, we uncompress the image file into a tmpdir
before creating the squashfs. In the case the source image is
uncompressed, eos-write-image ends up being a used as a slow version
of cp. This optimisation attempts to hardlink the file in the hope
that the source image and tmpdir are on the same device, but otherwise
falls back to the previous code.

https://phabricator.endlessm.com/T15394