### PR TITLE
write-live-image: remove redundant 'partprobe'

### DIFF
--- a/eos-tech-support/eos-write-live-image
+++ b/eos-tech-support/eos-write-live-image
@@ -348,7 +348,6 @@ EFI_PARTITIONS
     fi
 
     # Give udisks a chance to notice the new partitions
-    partprobe
     udevadm settle
 
     if [ ! "$MBR" ]; then


### PR DESCRIPTION
In both paths above, we have just written a new partition table to
$OUTPUT, then run `udevadm settle` and `partprobe $OUTPUT`. We still
need to let udev catch up after probing the new partition table but we
don't need to trigger a probe of all devices in the system.

If you have an Endless OS ISO attached to the system (on a different
device to $OUTPUT), the script would fail here:

    Warning: Unable to open /dev/sr0 read-write (Read-only file system).
    /dev/sr0 has been opened read-only.
    Warning: Unable to open /dev/sr0 read-write (Read-only file system).
    /dev/sr0 has been opened read-only.
    Error: Invalid partition table - recursive partition on /dev/sr0.

It's true that our ISOs have a weird partition table containing a
partition which spans the whole device; but it's irrelevant when we're
writing to a totally different device.

https://phabricator.endlessm.com/T15598