### PR TITLE
eos-core: add libnss-resolve for containers

### DIFF
--- a/eos-core-depends
+++ b/eos-core-depends
@@ -105,6 +105,7 @@ ibus-unikey
 # Needed to support some Epson scanners
 imagescan
 libreoffice
+libnss-resolve
 nautilus
 bluez-obexd
 openprinting-ppds


### PR DESCRIPTION
with systemd-networkd, systemd-resolved and libnss-resolve in
containers and host, we get seamless name resolution.

this is needed for: https://phabricator.endlessm.com/T15164

Signed-off-by: Niv Sardi <xaiki@evilgiggle.com>