### PR TITLE
eos-core Add eos-kalite-tools

### DIFF
--- a/eos-core-depends
+++ b/eos-core-depends
@@ -28,6 +28,7 @@ eos-gates
 eos-google-chrome-helper [amd64]
 eos-installer
 eos-kalite-system-helper
+eos-kalite-tools
 eos-language-pack-ar
 eos-language-pack-bn
 eos-language-pack-de


### PR DESCRIPTION
This will be needed for replicating KA Lite installations from one
machine into multiple destinations, both the flatpak and the data.

https://phabricator.endlessm.com/T15449