### PR TITLE
eos-core-depends: Add eos-updater-tools

### DIFF
--- a/eos-core-depends
+++ b/eos-core-depends
@@ -47,6 +47,7 @@ eos-phone-home
 eos-social
 eos-speedwagon
 eos-tutorial
+eos-updater-tools
 evince
 evolution
 file-roller


### PR DESCRIPTION
This contains the eos-updater-ctl and eos-updater-prepare-volume tools,
which can be useful for manually running the updater and preparing USB
drive updates for larger (or non-network connected) deployments.

Signed-off-by: Philip Withnall <withnall@endlessm.com>

https://phabricator.endlessm.com/T15895