### PR TITLE
eos-tech-support: Port eos-updater service handling to latest unit files

### DIFF
--- a/eos-tech-support/eos-convert-system
+++ b/eos-tech-support/eos-convert-system
@@ -10,12 +10,12 @@ echo "Configuring Metrics System for Dev"
 source eos-select-metrics-env 'dev'
 
 # Disable upgrade timer
-systemctl stop eos-autoupdater.timer
-systemctl disable eos-autoupdater.timer
+systemctl disable --now eos-autoupdater.timer
+systemctl stop eos-autoupdater.service
 
 # Unsure if these are necessary after stopping the timer, but better to be
 # sure.
-systemctl stop eos-autoupdater.service
+systemctl stop eos-updater.service
 
 # 4th element in mountinfo is the "root" within a mounted filesystem, 5th is
 # where it's mounted. Hence dig out where our root is coming from, so we're

--- a/eos-tech-support/eos-convert-system-qa
+++ b/eos-tech-support/eos-convert-system-qa
@@ -135,11 +135,10 @@ if $OSTREE || $APPS; then
         # Make sure the autoupdater doesn't start the updater after it's
         # killed below.
         echo "Stopping running eos-autoupdater."
-        systemctl stop eos-autoupdater.timer
-        systemctl stop eos-autoupdater.service
+        systemctl stop eos-autoupdater.timer eos-autoupdater.service
 
         echo "Killing eos-updater."
-        killall eos-updater &>/dev/null
+        systemctl stop eos-updater.service
 
         echo "Configuring OSTree for Staging."
         # HACK! HACK! HACK! ostree admin set-origin is horribly broken
@@ -154,8 +153,17 @@ if $OSTREE || $APPS; then
             --set=branches="${new_branch};"
 
         # Check for an update every time the updater runs
-        # rather than once every two weeks
-	sed -i 's/IntervalDays=14/IntervalDays=0/' /etc/eos-updater.conf
+        # rather than once every two weeks. eos-updater.conf is the old
+        # location of the config file.
+        sed -i 's/IntervalDays=14/IntervalDays=0/' /etc/eos-updater/eos-autoupdater.conf 2>/dev/null || true
+        sed -i 's/IntervalDays=14/IntervalDays=0/' /etc/eos-updater.conf 2>/dev/null || true
+
+        if [ ! -f /etc/eos-updater/eos-autoupdater.conf ] && [ ! -f /etc/eos-updater.conf ]; then
+            mkdir -p /etc/eos-updater
+            cp /usr/share/eos-updater/eos-autoupdater.conf /etc/eos-updater
+
+            sed -i 's/IntervalDays=14/IntervalDays=0/' /etc/eos-updater/eos-autoupdater.conf
+        fi
     fi
 fi
 

--- a/eos-tech-support/eos-dev-fix
+++ b/eos-tech-support/eos-dev-fix
@@ -37,12 +37,12 @@ if [ $(readlink -f ${OSTREE_DEPLOY_BOOTED}) != \
 fi
 
 # Disable upgrade timer
-systemctl stop eos-autoupdater.timer
-systemctl disable eos-autoupdater.timer
+systemctl disable --now eos-autoupdater.timer
+systemctl stop eos-autoupdater.service
 
 # Unsure if these are necessary after stopping the timer, but better to be
 # sure.
-systemctl stop eos-autoupdater.service
+systemctl stop eos-updater.service
 
 echo -e "\nAutomatic upgrades have been stopped," \
   "your system can no longer be upgraded using ostree beyond this point!"


### PR DESCRIPTION
The eos-updater unit files changed recently (eos-updater.service was
created, having previously been an alias for eos-autoupdater.service).
Update the tech support scripts to reflect this.

Additionally, the configuration file locations for eos-updater changed:
/etc/eos-updater.conf moved to /etc/eos-updater/eos-autoupdater.conf.

Signed-off-by: Philip Withnall <withnall@endlessm.com>

https://phabricator.endlessm.com/T15977