### PR TITLE
T16069: permit only signed grub on amd64 ostrees

### DIFF
--- a/os-depends
+++ b/os-depends
@@ -32,7 +32,7 @@ gnome-session
 gnupg
 # Could just be i386 amd64, but theoretically supports other arches
 grub2 [!armhf]
-grub-efi-amd64-image-signed [amd64] | grub-efi-amd64-image [i386 amd64]
+grub-efi-amd64-image-signed [amd64] | grub-efi-amd64-image [i386]
 iproute2
 less
 libpam-fprintd


### PR DESCRIPTION
The well-intentioned grub-efi-amd64-image-signed | grub-efi-amd64-image which was handy for development means we can accidentally build ostrees without a signed grub EFI binary, depending on the state of the package archives, signing servers, etc. Remove this possibility.

https://phabricator.endlessm.com/T16069