### PR TITLE
T16069: remove possibility of unsigned kernel on amd64

### DIFF
--- a/os-depends
+++ b/os-depends
@@ -43,8 +43,8 @@ linux-firmware
 # those appear in the platform specific -depends files. For amd64,
 # prefer the linux-signed-image variant, which contains the kernel
 # signed for UEFI. The -64 variant is a 64 bit kernel that we install on
-# i386. For all other architectures, we want to use the normal variant.
-linux-signed-image-generic [amd64] | linux-image-generic-64 [i386] | linux-image-generic [!armhf]
+# i386.
+linux-signed-image-generic [amd64] | linux-image-generic-64 [i386]
 lsb-base
 lsb-release
 mobile-broadband-provider-info


### PR DESCRIPTION
Ensure we don't have a configuration where eos-meta can be installed on amd64 with an unsigned kernel image.

https://phabricator.endlessm.com/T16069