### PR TITLE
Add gtk-3-examples to com.endlessm.Sdk

### DIFF
--- a/eos-sdk-runtime-depends
+++ b/eos-sdk-runtime-depends
@@ -18,6 +18,7 @@ flex
 gdb
 git
 gperf
+gtk-3-examples
 gtk-doc-tools
 libclutter-1.0-dev
 libclutter-gst-2.0-dev


### PR DESCRIPTION
This is to allow running gtk3-widget-factory as a dev tool.

https://phabricator.endlessm.com/T16555