### PR TITLE
eos-platform-runtime-depends: add libgtk-3-0 for xim support

### DIFF
--- a/eos-platform-runtime-depends
+++ b/eos-platform-runtime-depends
@@ -5,6 +5,7 @@ include base-depends
 
 # Flatpak platform additions
 fontconfig-config-flatpak
+libgtk-3-0
 
 # Dependencies for apps included in the runtime.
 eos-extra-fonts


### PR DESCRIPTION
https://phabricator.endlessm.com/T16264#371491