### PR TITLE
eos-diagnostics: Don't check for personality file

### DIFF
--- a/eos-tech-support/eos-diagnostics
+++ b/eos-tech-support/eos-diagnostics
@@ -421,13 +421,6 @@ let diagnostics = [
         },
     },
     {
-        title: 'EndlessOS personality',
-        content: function() {
-            return tryReadFile('/etc/EndlessOS/personality.conf',
-                               'No personality file\n');
-        },
-    },
-    {
         title: 'Uptime',
         content: function() { return trySpawn('uptime'); },
     },


### PR DESCRIPTION
The file is no longer generated, and we can determine the
personality from the image name.

https://phabricator.endlessm.com/T17029