### PR TITLE
ISO: embed md5sums

### DIFF
--- a/eos-tech-support/eos-write-live-image
+++ b/eos-tech-support/eos-write-live-image
@@ -534,6 +534,7 @@ if [ "$ISO" ]; then
 	    -joliet -joliet-long \
 	    -volid "$VOLID" \
 	    -publisher 'Endless Computers' \
+	    --md5 \
 	    ${DIR_IMAGES}
 
     # Change partition type from 0x83 to 0x00


### PR DESCRIPTION
Untested! And non-working. Interestingly the MD5 sums embedded by this flag – if indeed there are any – are not the same as those embedded by `implantisomd5`.