### PR TITLE
Add eos-core-nexthw package

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -99,6 +99,19 @@ Description: Target packages of the Endless distribution for S905X-based boards
  .
  This set provides the platform specific package list for armhf-s905x
 
+Package: eos-core-nexthw
+Architecture: amd64
+Depends: ${misc:Depends}, ${eos:Depends}
+Description: Target packages of the Endless distribution for amd64 nexthw
+ This package depends on all packages required for the Endless OS core images
+ .
+ It is also used to help ensure proper upgrades, so it is recommended that
+ it not be removed.
+ .
+ This set provides the platform specific package list for amd64 nexthw
+ builds. These builds provide newer hardware enablement on top of the
+ standard amd64 builds.
+
 Package: eos-installer-meta
 Architecture: any
 Depends: ${misc:Depends}, ${eos:Depends}

--- a/eos-core-nexthw-depends
+++ b/eos-core-nexthw-depends
@@ -1,0 +1,1 @@
+eos-core-amd64


### PR DESCRIPTION
For nexthw builds, the ostree builder will use the "nexthw" platform,
so we need an appropriate core package. Add one that is just a simple
reference to the standard eos-core-amd64.

https://phabricator.endlessm.com/T15591