### PR TITLE
Install eos-b43fw-install

### DIFF
--- a/os-depends
+++ b/os-depends
@@ -8,6 +8,7 @@ dconf-cli
 dosfstools
 dracut
 efibootmgr [amd64]
+eos-b43fw-install
 eos-boot-helper
 eos-composite-mode
 eos-default-background


### PR DESCRIPTION
This is a script which downloads Broadcom proprietary Linux drivers from
the web, extracts the firmware files needed by the open source drivers
from the proprietary drivers, and install the firmware files in the
right place.

eos-b43fw-clean is also provided by the same package to uninstall these
files, if needed.

https://phabricator.endlessm.com/T12154