### PR TITLE
enable MP3 encoding in the OS

### DIFF
--- a/base-depends
+++ b/base-depends
@@ -10,6 +10,7 @@ fonts-wqy-microhei
 gnome-themes-standard
 gstreamer1.0-libav
 gstreamer1.0-plugins-good
+gstreamer1.0-plugins-ugly-lame
 gstreamer1.0-pulseaudio
 gstreamer1.0-tools
 libcanberra-gtk-module

--- a/eos-platform-runtime-depends
+++ b/eos-platform-runtime-depends
@@ -79,6 +79,7 @@ libkunitconversion4
 liblockfile-bin
 liblua5.1-0
 liblua5.2-0
+libmp3lame0
 libmtdev1
 libpangomm-1.4-1
 libpulse0


### PR DESCRIPTION
- add gstreamer1.0-plugins-ugly-lame package to the base depends
  (for Rhythmbox and any other GStreamer apps in the OS/runtime)
- add libmp3lame0 explicitly to the runtime for Audacity (effectively
  redundant with the above, but more explicit/strictly correct)

https://phabricator.endlessm.com/T16932