### PR TITLE
eos-core-depends: add gnome-logs

### DIFF
--- a/eos-core-depends
+++ b/eos-core-depends
@@ -85,6 +85,7 @@ gnome-clocks
 gnome-control-center
 gnome-font-viewer
 gnome-initial-setup
+gnome-logs
 gnome-orca
 gnome-screenshot
 gnome-software


### PR DESCRIPTION
https://phabricator.endlessm.com/T13612