### PR TITLE
eos-list-users: work correctly on live USBs

### DIFF
--- a/eos-tech-support/eos-list-users
+++ b/eos-tech-support/eos-list-users
@@ -46,7 +46,7 @@ list_users() {
 list_dualboot_users() {
     local PHYSICAL_DEVICE=${1:?}
 
-    mount $NAME $MOUNT
+    mount $PHYSICAL_DEVICE $MOUNT
     local ENDLESS_IMG="$MOUNT/endless/endless.img"
 
     if [ -e "$ENDLESS_IMG" ] && [ ! -e "$MOUNT/endless/live" ]; then

--- a/eos-tech-support/eos-list-users
+++ b/eos-tech-support/eos-list-users
@@ -82,9 +82,14 @@ BD_MBR="0x7"
 BD_GPT="EBD0A0A2-B9E5-4433-87C0-68B6B72699C7"
 
 echo
-DEVICES=$(lsblk --raw --paths --noheadings -o NAME,PARTTYPE,LABEL)
-while read NAME PARTTYPE LABEL; do
-    if [ "${LABEL}" == "ostree" ]; then
+DEVICES=$(lsblk --raw --paths --noheadings -o NAME,PARTTYPE,LABEL,RO)
+while read NAME PARTTYPE LABEL RO; do
+    if [ "${RO}" == "1" ]; then
+        # Skip read-only partitions, such as the eoslive partition on a live
+        # USB or the /dev/mapper/endless-image3 ostree partition mapped within
+        # it.
+        :
+    elif [ "${LABEL}" == "ostree" ]; then
         list_users $NAME $NAME
     elif [ "${PARTTYPE}" == "${BD_MBR}" ] || \
          [ "${PARTTYPE^^}" == "${BD_GPT}" ]; then

--- a/eos-tech-support/eos-list-users
+++ b/eos-tech-support/eos-list-users
@@ -31,7 +31,10 @@ list_users() {
     local DEVICE=$1
     local PHYSICAL_DEVICE=$2
 
-    mount $DEVICE $MOUNT
+    if ! mount $DEVICE $MOUNT; then
+        echo "Can't list users on $PHYSICAL_DEVICE" >&2
+        return
+    fi
 
     # FIXME A more robust approach would be the following:
     # - read /usr/etc/login.defs and extract UID_MIN
@@ -46,7 +49,11 @@ list_users() {
 list_dualboot_users() {
     local PHYSICAL_DEVICE=${1:?}
 
-    mount $PHYSICAL_DEVICE $MOUNT
+    if ! mount $PHYSICAL_DEVICE $MOUNT; then
+        echo "Can't list users on $PHYSICAL_DEVICE" >&2
+        return
+    fi
+
     local ENDLESS_IMG="$MOUNT/endless/endless.img"
 
     if [ -e "$ENDLESS_IMG" ] && [ ! -e "$MOUNT/endless/live" ]; then


### PR DESCRIPTION
Without these changes:

```
live@endless:~$ sudo eos-list-users 

FUSE exfat 1.2.3
WARN: '/dev/sdb1' is write-protected, mounting read-only.
fuse: mount failed: Device or resource busy
```

With these changes:

```
live@endless:~$ sudo ~/src/endlessm/eos-meta/eos-tech-support/eos-list-users 

Users on /dev/sda3:
guybrush  shared  wjt

```

I am open to alternative suggestions for how to skip the booted image host partition and mapped ostree partition, but the read-only flag seems the most straightforward to me!

https://phabricator.endlessm.com/T17560