### PR TITLE
eos-diagnostics: log rfkill devices and state

### DIFF
--- a/eos-tech-support/eos-diagnostics
+++ b/eos-tech-support/eos-diagnostics
@@ -180,6 +180,39 @@ function collectI2cDevices() {
     return output;
 }
 
+function collectRfkill() {
+    let dir = Gio.File.new_for_path('/sys/class/rfkill');
+    let fileEnum;
+    let output = '';
+
+    try {
+        fileEnum = dir.enumerate_children('standard::name',
+                                          Gio.FileQueryInfoFlags.NONE, null);
+    } catch (e) {
+        return '';
+    }
+
+    let info;
+    while ((info = fileEnum.next_file(null))) {
+        let devDir = fileEnum.get_child(info).get_path();
+        output += info.get_name() + '\n';
+        output += '  name: ' + tryReadFile(devDir + '/name');
+        output += '  type: ' + tryReadFile(devDir + '/type');
+        output += '  hard: ' + tryReadFile(devDir + '/hard');
+        output += '  soft: ' + tryReadFile(devDir + '/soft');
+        output += '  persistent: ' + tryReadFile(devDir + '/persistent');
+        output += '  state: ' + tryReadFile(devDir + '/state');
+        try {
+            let driver = GLib.file_read_link(devDir + '/device/device/driver');
+            output += '  driver: ' + GLib.path_get_basename(driver) + '\n';
+        } catch (e) { }
+
+        output += '\n';
+    }
+
+    return output;
+}
+
 function collectHdaProcCodecInfo(dir) {
     let output = '';
     let fileEnum;
@@ -461,6 +494,11 @@ let diagnostics = [
         title: 'Network interfaces',
         hardwareInfo: true,
         content: function() { return trySpawn('ifconfig -a'); },
+    },
+    {
+        title: 'rfkill devices',
+        hardwareInfo: true,
+        content: function() { return collectRfkill(); },
     },
     {
         title: 'Graphics',


### PR DESCRIPTION
We have a few user support issues where we see the wifi blocked,
but it's not clear if its software- or hardware-blocked nor what
exactly is behind it.

Now we log each rfkill device, name, type, and driver, and:
 1. soft
    Whether it has been blocked in software (and hence can be unblocked)
 2. hard
    Whether something in the hardware has blocked it (can't be unblocked in
    software)
 3. persistent
    Whether the soft-blocked state is initialiased from non-volatile storage

These are all well documented in the kernel's ABI documentation.

https://phabricator.endlessm.com/T17620