### PR TITLE
os-depends: add eos-version-number

### DIFF
--- a/os-depends
+++ b/os-depends
@@ -19,6 +19,7 @@ eos-license-service
 eos-plymouth-theme
 eos-tech-support
 eos-updater
+eos-version-number
 exfat-fuse
 exfat-utils
 fake-hwclock


### PR DESCRIPTION
This package will set the version number in /etc/os-release
from this point onwards.

https://phabricator.endlessm.com/T17633