### PR TITLE
eos-write-image: detect removable media automatically

### DIFF
--- a/eos-tech-support/eos-write-image
+++ b/eos-tech-support/eos-write-image
@@ -24,7 +24,12 @@ Options:
    --debug      turn on debugging messages
    --removable  device is removable (remove fallback.efi);
                 not supported if DEVICE is '-'
+   --fixed      device is not removable (don't remove fallback.efi)
    -h,--help    show this message
+Note:
+   If neither --removable nor --fixed is specified, 'lsblk -o HOTPLUG' is used
+   to guess; the guess will be shown before you're asked to proceed with
+   writing.
 EOF
 }
 
@@ -47,7 +52,19 @@ while true; do
             shift
             ;;
         --removable)
-            REMOVABLE=true
+            if [ "$REMOVABLE" = "0" ]; then
+                echo "--removable and --fixed cannot both be used" >&2
+                exit 1
+            fi
+            REMOVABLE=1
+            shift
+            ;;
+        --fixed)
+            if [ "$REMOVABLE" = "1" ]; then
+                echo "--removable and --fixed cannot both be used" >&2
+                exit 1
+            fi
+            REMOVABLE=0
             shift
             ;;
         -h|--help)
@@ -145,13 +162,13 @@ cat_image() {
 
         # ISO images do not need to be mangled
         if [[ "$MIME_TYPE" =~ x-iso9660-image$ ]]; then
-            REMOVABLE=
+            REMOVABLE=0
         fi
     fi
 }
 
 if [ "$DEVICE" == "-" ]; then
-    if [ "$REMOVABLE" ]; then
+    if [ "$REMOVABLE" = "1" ]; then
         echo "--removable not supported when writing to stdout" >&2
         exit 1
     fi
@@ -173,6 +190,17 @@ else
         exit 1
     fi
 
+    if [ ! "$REMOVABLE" ]; then
+        REMOVABLE=$(lsblk --raw --nodeps --noheading --output HOTPLUG "$DEVICE")
+        if [ "$REMOVABLE" = 1 ]; then
+            echo "Guessed that $DEVICE is a removable disk;" \
+                 "pass --fixed if this is wrong." >&2
+        else
+            echo "Guessed that $DEVICE is a fixed disk;" \
+                 "pass --removable if this is wrong." >&2
+        fi
+    fi
+
     if [ ! "$FORCE" ]; then
         read -p "Are you sure you want to overwrite all data on $DEVICE? [y/N] "
         response="${REPLY,,}" # to lower
@@ -190,7 +218,7 @@ else
     udevadm settle
 
     # If removable device, delete $ESP/EFI/BOOT/fallback.efi
-    if [ "$REMOVABLE" ]; then
+    if [ "$REMOVABLE" = "1" ]; then
         # Assume ESP is the first partition
         case "$DEVICE" in
             /dev/mmcblk?)


### PR DESCRIPTION
The heuristics available from lsblk to detect removable media are:

* RM: matches the 'removable' attribute in sysfs. This is 1 for all
  USB sticks I have handy, 0 for the removable SD card inserted
  into my laptop, and 0 for a soldered-in MMC in at least one other
  laptop.
* HOTPLUG: 1 if RM is 1, or if the device chain includes a USB,
  IEEE1394, PCMCIA, MMC or CCW device. This is 1 for all devices
  mentioned above.

As discussed at https://phabricator.endlessm.com/T17871#409848
https://bugs.freedesktop.org/show_bug.cgi?id=49844 and elsewhere, these
heuristics are imperfect but we cannot do much better.

If we falsely believe a fixed device (eg soldered-on MMC) to be
removable, we will rely on the firmware loading the default boot path
\efi\boot\bootx64.efi for every boot. (This is what we did for all
systems prior to Endless OS 3.1.)

If we falsely believe a removable device (eg USB stick, or removable
MMC!) to be fixed, booting it on an EFI system erases the system's boot
configuration.  This has happened in the wild and is particularly bad on
dual-boot systems, since Windows' \efi\boot\bootx64.efi knows how to
boot Windows, but not (of course) Endless OS.

I think the latter is more dangerous, so let's err on the side of
caution and use HOTPLUG.

https://phabricator.endlessm.com/T17871#409848