### PR TITLE
fix inclusion of OpenVPN support

### DIFF
--- a/eos-core-depends
+++ b/eos-core-depends
@@ -8,6 +8,7 @@ alsa-utils
 apt
 apt-transport-https
 apt-utils
+avahi-daemon
 bluez-obexd
 brasero
 btrfs-tools

--- a/eos-core-depends
+++ b/eos-core-depends
@@ -111,6 +111,7 @@ imagescan
 libreoffice
 nautilus
 network-manager-openvpn-gnome
+network-manager-vpnc-gnome
 openprinting-ppds
 openssh-server
 printer-driver-all

--- a/eos-core-depends
+++ b/eos-core-depends
@@ -21,6 +21,7 @@ cups
 debconf-i18n
 eog
 eos-acknowledgements
+eos-b43fw-install
 eos-browser-tools
 eos-chrome-plugin-updater
 eos-codecs-manager

--- a/eos-core-depends
+++ b/eos-core-depends
@@ -132,8 +132,6 @@ unoconv
 unrar
 vinagre
 vino
-virtualbox-guest-utils [amd64]
-virtualbox-guest-x11 [amd64]
 whiptail
 xapian-bridge
 xdg-desktop-portal

--- a/eos-core-depends
+++ b/eos-core-depends
@@ -110,7 +110,7 @@ ibus-unikey
 imagescan
 libreoffice
 nautilus
-network-manager-openvpn
+network-manager-openvpn-gnome
 openprinting-ppds
 openssh-server
 printer-driver-all

--- a/os-depends
+++ b/os-depends
@@ -8,7 +8,6 @@ dconf-cli
 dosfstools
 dracut
 efibootmgr [amd64]
-eos-b43fw-install
 eos-boot-helper
 eos-composite-mode
 eos-default-background

--- a/os-depends
+++ b/os-depends
@@ -54,7 +54,6 @@ module-init-tools
 net-tools
 network-manager
 network-manager-gnome
-network-manager-vpnc-gnome
 ntp
 openssh-client
 ostree

--- a/os-depends
+++ b/os-depends
@@ -74,6 +74,8 @@ u-boot-tools [armhf]
 udev
 usb-modeswitch
 vim-tiny
+virtualbox-guest-utils [amd64]
+virtualbox-guest-x11 [amd64]
 wpasupplicant
 xauth
 xdg-user-dirs

--- a/os-depends
+++ b/os-depends
@@ -1,6 +1,5 @@
 # Dependencies shared between OS metapackages
 adduser
-avahi-daemon
 bluez
 cryptsetup
 dbus-x11


### PR DESCRIPTION
network-manager-openvpn apparently doesn't work without -openvpn-gnome, so it's better to depend
on that one directly, similar to -vpnc-gnome which we already have.

Also found a bunch of other things which weren't necessarily in the right place os-depends (shared with eos-installer) vs eos-core.

https://phabricator.endlessm.com/T17912