### PR TITLE
Drop libreoffice from core packages

### DIFF
--- a/eos-core-depends
+++ b/eos-core-depends
@@ -110,7 +110,6 @@ ibus-table-wubi
 ibus-unikey
 # Needed to support some Epson scanners
 imagescan
-libreoffice
 nautilus
 network-manager-openvpn-gnome
 network-manager-vpnc-gnome

--- a/eos-language-pack-ar-depends
+++ b/eos-language-pack-ar-depends
@@ -1,3 +1,2 @@
 aspell-ar
 hunspell-ar
-libreoffice-l10n-ar

--- a/eos-language-pack-bn-depends
+++ b/eos-language-pack-bn-depends
@@ -1,1 +1,0 @@
-libreoffice-l10n-bn

--- a/eos-language-pack-de-depends
+++ b/eos-language-pack-de-depends
@@ -1,1 +1,0 @@
-libreoffice-l10n-de

--- a/eos-language-pack-en-depends
+++ b/eos-language-pack-en-depends
@@ -1,3 +1,2 @@
 hunspell-en-us
 hyphen-en-us
-libreoffice-help-en-us

--- a/eos-language-pack-es-depends
+++ b/eos-language-pack-es-depends
@@ -1,5 +1,3 @@
 aspell-es
-libreoffice-help-es
-libreoffice-l10n-es
 myspell-es
 wspanish

--- a/eos-language-pack-fr-depends
+++ b/eos-language-pack-fr-depends
@@ -1,3 +1,2 @@
 aspell-fr
 hunspell-fr
-libreoffice-l10n-fr

--- a/eos-language-pack-id-depends
+++ b/eos-language-pack-id-depends
@@ -1,1 +1,0 @@
-libreoffice-l10n-id

--- a/eos-language-pack-pt-br-depends
+++ b/eos-language-pack-pt-br-depends
@@ -1,4 +1,2 @@
 aspell-pt-br
-libreoffice-help-pt-br
-libreoffice-l10n-pt-br
 myspell-pt-br

--- a/eos-language-pack-pt-depends
+++ b/eos-language-pack-pt-depends
@@ -1,3 +1,2 @@
 aspell-pt-pt
-libreoffice-l10n-pt
 myspell-pt

--- a/eos-language-pack-ro-depends
+++ b/eos-language-pack-ro-depends
@@ -1,1 +1,0 @@
-libreoffice-l10n-ro

--- a/eos-language-pack-th-depends
+++ b/eos-language-pack-th-depends
@@ -1,2 +1,1 @@
-libreoffice-l10n-th
 myspell-th

--- a/eos-language-pack-vi-depends
+++ b/eos-language-pack-vi-depends
@@ -1,2 +1,1 @@
 hunspell-vi
-libreoffice-l10n-vi

--- a/eos-language-pack-zh-cn-depends
+++ b/eos-language-pack-zh-cn-depends
@@ -1,1 +1,0 @@
-libreoffice-l10n-zh-cn

--- a/eos-language-pack-zh-tw-depends
+++ b/eos-language-pack-zh-tw-depends
@@ -1,1 +1,0 @@
-libreoffice-l10n-zh-tw


### PR DESCRIPTION
libreoffice is not buildable on current master, and the plan is
to move it into a flatpak for EOS-3.3.

https://phabricator.endlessm.com/T14879