### PR TITLE
eos-core: eos-google-chrome-helper was renamed

### DIFF
--- a/eos-core-depends
+++ b/eos-core-depends
@@ -30,7 +30,7 @@ eos-discovery-feed
 eos-event-recorder-daemon
 eos-exploration-center
 eos-gates
-eos-google-chrome-helper [amd64]
+eos-install-app-helper [amd64]
 eos-installer
 eos-kalite-system-helper
 eos-kalite-tools


### PR DESCRIPTION
https://phabricator.endlessm.com/T16839