### PR TITLE
add eos-google-chrome-helper as a separate package

### DIFF
--- a/eos-core-depends
+++ b/eos-core-depends
@@ -30,6 +30,7 @@ eos-discovery-feed
 eos-event-recorder-daemon
 eos-exploration-center
 eos-gates
+eos-google-chrome-helper [amd64]
 eos-install-app-helper [amd64]
 eos-installer
 eos-kalite-system-helper


### PR DESCRIPTION
The Google Chrome helper functionality is being reinstated in the
eos-browser-tools package, so we need both binary packages now.

https://phabricator.endlessm.com/T16839