### PR TITLE
eos-download-image: handle missing manifest gracefully

### DIFF
--- a/eos-tech-support/eos-download-image
+++ b/eos-tech-support/eos-download-image
@@ -161,9 +161,9 @@ class EosDownloadImage(object):
         # keyring from the gnupg homedir
         keyring = os.path.abspath(os.path.join(
             self.args.outdir, KEYRING_FILENAME))
-        if not os.path.isfile(keyring):
-            log("Fetching Endless keyring")
-            self.download(KEYRING_URL, keyring)
+
+        log("Fetching Endless keyring")
+        self.download(KEYRING_URL, keyring)
 
         return keyring
 

--- a/eos-tech-support/eos-download-image
+++ b/eos-tech-support/eos-download-image
@@ -298,8 +298,16 @@ class EosDownloadImage(object):
     def fetch_manifest(self):
         manifest_url = '{base}/releases-{product}-3.json'.format(
             base=self.base, product=self.args.product)
-        manifest = self.session.get(manifest_url).json()
+        response = self.session.get(manifest_url)
 
+        try:
+            response.raise_for_status()
+        except requests.exceptions.HTTPError as e:
+            log("Couldn't fetch manifest for product", self.args.product)
+            log(e)
+            sys.exit(1)
+
+        manifest = response.json()
         images = list(manifest['images'].values())
         images.sort(key=lambda i: distutils.version.LooseVersion(i['version']))
         return manifest, images


### PR DESCRIPTION
Without this change, running `eos-download-image --product esodvd` gives
you a long traceback followed by:

    json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)

With this change, you get a more human-readable error describing the
actual cause:

    Couldn't fetch manifest for product esodvd

    403 Client Error: Forbidden for url: https://d1anzknqnc1kmb.cloudfront.net/releases-esodvd-3.json

Found while QAing https://phabricator.endlessm.com/T18653