### PR TITLE
eos-dev: Include endless-ca-cert

### DIFF
--- a/eos-dev-depends
+++ b/eos-dev-depends
@@ -16,6 +16,7 @@ devscripts
 diffutils
 elinks
 emacs
+endless-ca-cert
 eos-node-modules-dev
 exuberant-ctags
 flex


### PR DESCRIPTION
The endless-ca-cert package provides the Endless SSL CA root certificate
and includes it in the system trusted store. This certificate is to sign
SSL certificates for internal Endless services. See
https://phabricator.endlessm.com/w/sysadmin/ssl-ca/ for details.

https://phabricator.endlessm.com/T18743