### PR TITLE
base-depends: Update EGL and GLES2 dependencies

### DIFF
--- a/base-depends
+++ b/base-depends
@@ -19,9 +19,9 @@ libcanberra-pulse
 libcaribou-gtk-module
 libcaribou-gtk3-module
 # Mali used on arm
-libegl1-mesa-drivers [!armhf]
+libegl1 [!armhf]
 # Mali used on arm
-libgles2-mesa [!armhf]
+libgles2 [!armhf]
 libglib2.0-data
 libglu1-mesa [!armhf]
 libnss-altfiles


### PR DESCRIPTION
These APIs are now provided by packages built from libglvnd source
package:

 - libegl1   replaced  libegl1-mesa
 - libgles2  replaced  libgles2-mesa
 - libgl1    replaced  libgl1-mesa-glx
 - libglx0   replaced  libgl1-mesa-glx

libegl1-mesa-drivers was a leftover from a previous mesa, and should
have been replaced with libegl1-mesa.

https://phabricator.endlessm.com/T18579