### PR TITLE
eos-write-live-image: remove --iso, cleanup

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -303,9 +303,3 @@ Description: EndlessOS Technical Support Tools
  with the EndlessOS operating system.  They are not required as part of the
  normal user experience but are relatively small and helpful for advanced
  troubleshooting.
-
-Package: eos-tech-support-iso
-Architecture: all
-Depends: ${misc:Depends}, ${eos:Depends}
-Description: Create Endless OS ISO Images
- Tools needed to create ISO images which are not needed in end-user images.

--- a/eos-tech-support-iso-depends
+++ b/eos-tech-support-iso-depends
@@ -1,7 +1,0 @@
-eos-tech-support
-dosfstools
-genisoimage
-grub-common
-mtools
-squashfs-tools
-xorriso

--- a/eos-tech-support/eos-write-image
+++ b/eos-tech-support/eos-write-image
@@ -116,7 +116,7 @@ fi
 DD_IN_OPTS+=(bs="$BLOCK_SIZE")
 DD_OUT_OPTS+=(bs="$BLOCK_SIZE")
 
-if [ "$USERID" != "0" ]; then
+if [ "$DEVICE" != "-" ] && [ "$USERID" != "0" ]; then
     echo "Program requires superuser privileges" >&2
     exit 1
 fi

--- a/eos-tech-support/eos-write-live-image
+++ b/eos-tech-support/eos-write-live-image
@@ -439,7 +439,7 @@ if [ ! "$WRITABLE" ]; then
     echo "$OS_IMAGE_UNCOMPRESSED_BASENAME" > "${DIR_IMAGES_ENDLESS}/live"
     cp "$WINDOWS_TOOL" "$DIR_IMAGES/"
     WINDOWS_TOOL_BASENAME="$(basename "$WINDOWS_TOOL")"
-    iconv -f utf-8 -t utf-16 <<AUTORUN_INF > "${DIR_IMAGES}/autorun.inf"
+    sed 's/$/\r/' <<AUTORUN_INF | iconv -f utf-8 -t utf-16 > "${DIR_IMAGES}/autorun.inf"
 [AutoRun]
 label=${LABEL}
 icon=${WINDOWS_TOOL_BASENAME}

--- a/eos-tech-support/eos-write-live-image
+++ b/eos-tech-support/eos-write-live-image
@@ -450,24 +450,6 @@ MusicFiles=false
 PictureFiles=false
 VideoFiles=false
 AUTORUN_INF
-
-    # Work around a bug in eos-installer, which only shows images whose
-    # personality is 'base' or a valid locale. Delete this block once
-    # 3.1.1 is released.
-    if [[ "${OS_IMAGE_UNCOMPRESSED_BASENAME}" == fnde-eos3.1-*.17011*.fnde_* ]]; then
-       for i in "$DIR_IMAGES_ENDLESS"/*; do
-          j=${i/fnde_aluno/base}
-          j=${j/fnde_escola/pt_BR}
-          if [ "$i" != "$j" ]; then
-             mv $i $j
-          fi
-       done
-
-       j=${OS_IMAGE_UNCOMPRESSED_BASENAME}
-       j=${j/fnde_aluno/base}
-       j=${j/fnde_escola/pt_BR}
-       echo "$j" > "${DIR_IMAGES_ENDLESS}/live"
-    fi
 fi
 
 # attempt to avoid copy if input image is already compressed but fall back

--- a/eos-tech-support/eos-write-live-image
+++ b/eos-tech-support/eos-write-live-image
@@ -55,24 +55,24 @@ Usage:
     $SELF IMAGE OUTPUT
 
 Arguments:
-    OUTPUT                 Device path (e.g. '/dev/sdb')
+    OUTPUT                   Device path (e.g. '/dev/sdb')
 
 Options:
-   -o,--os-image IMAGE     Path to Endless OS image
-   -x,--windows-tool PATH  Path to Endless OS installer tool for Windows
-   -l,--latest             Fetch latest OS image and/or Windows tool
-   -p,--personality        Fetch a different personality (default: $PERSONALITY)
-   -r,--product            Fetch a different product (default: $PRODUCT)
-   -L,--label LABEL        Autorun.inf label (default: Endless OS)
-   -w,--writable           Allow image to be modified when run (which
-                           prevents installing it later)
-   -f,--force              don't ask to proceed before writing
-   -h,--help               Show this message
+    -o, --os-image IMAGE     Path to Endless OS image
+    -x, --windows-tool PATH  Path to Endless OS installer tool for Windows
+    -l, --latest             Fetch latest OS image and/or Windows tool
+    -p, --personality        Fetch a different personality (default: $PERSONALITY)
+    -r, --product            Fetch a different product (default: $PRODUCT)
+    -L, --label LABEL        Autorun.inf label (default: Endless OS)
+    -w, --writable           Allow image to be modified when run (which
+                             prevents installing it later)
+    -f, --force              don't ask to proceed before writing
+    -h, --help               Show this message
 
 Developer options (you probably don't want to use these):
-   -n,--ntfs               Format the image partition as NTFS, not exFAT
-   -m,--mbr                Format DEVICE as MBR, not GPT
-   --debug                 Enable debugging output
+    -n, --ntfs               Format the image partition as NTFS, not exFAT
+    -m, --mbr                Format DEVICE as MBR, not GPT
+        --debug              Enable debugging output
 EOF
 }
 

--- a/eos-tech-support/eos-write-live-image
+++ b/eos-tech-support/eos-write-live-image
@@ -19,7 +19,7 @@ if [ ! -f $EOS_DOWNLOAD_IMAGE ]; then
     EOS_DOWNLOAD_IMAGE='eos-download-image'
 fi
 
-ARGS=$(getopt -o o:x:lp:r:nmwiL:fh \
+ARGS=$(getopt -o o:x:lp:r:nmwL:fh \
     -l os-image: \
     -l windows-tool: \
     -l latest \
@@ -28,11 +28,7 @@ ARGS=$(getopt -o o:x:lp:r:nmwiL:fh \
     -l ntfs \
     -l mbr \
     -l writable \
-    -l iso \
     -l label: \
-    -l delete-os-image \
-    -l squashfs-comp: \
-    -l squashfs-b: \
     -l force \
     -l debug \
     -l help \
@@ -41,15 +37,11 @@ eval set -- "$ARGS"
 
 NTFS=
 MBR=
-ISO=
 WRITABLE=
 FORCE=
 PERSONALITY=base
 PRODUCT=eos
 LABEL=
-DELETE_OS_IMAGE=
-SQUASHFS_COMP=gzip
-SQUASHFS_B=131072
 DEBUG=
 
 usage() {
@@ -62,7 +54,7 @@ Usage:
     $SELF IMAGE OUTPUT
 
 Arguments:
-    OUTPUT                 Device path (e.g. '/dev/sdb') or ISO image
+    OUTPUT                 Device path (e.g. '/dev/sdb')
 
 Options:
    -o,--os-image IMAGE     Path to Endless OS image
@@ -70,17 +62,11 @@ Options:
    -l,--latest             Fetch latest OS image and/or Windows tool
    -p,--personality        Fetch a different personality (default: $PERSONALITY)
    -r,--product            Fetch a different product (default: $PRODUCT)
+   -L,--label LABEL        Autorun.inf label (default: Endless OS)
    -w,--writable           Allow image to be modified when run (which
                            prevents installing it later)
    -f,--force              don't ask to proceed before writing
    -h,--help               Show this message
-
-ISO 9660-related options:
-   -i,--iso                Write an ISO 9660 disk image to OUTPUT
-   -L,--label LABEL        ISO volume id and Autorun.inf label
-   --delete-os-image       Delete IMAGE after creating SquashFS wrapper
-   --squashfs-comp COMP    Pass '-comp COMP' to mksquashfs (default: $SQUASHFS_COMP)
-   --squashfs-b BLOCK_SIZE Pass '-b BLOCK_SIZE' to mksquashfs (default: $SQUASHFS_B)
 
 Developer options (you probably don't want to use these):
    -n,--ntfs               Format the image partition as NTFS, not exFAT
@@ -152,27 +138,9 @@ while true; do
             shift
             WRITABLE=true
             ;;
-        -i|--iso)
-            shift
-            ISO=true
-            ;;
         -L|--label)
             shift
             LABEL="$1"
-            shift
-            ;;
-        --delete-os-image):
-            shift
-            DELETE_OS_IMAGE=true
-            ;;
-        --squashfs-comp):
-            shift
-            SQUASHFS_COMP="$1"
-            shift
-            ;;
-        --squashfs-b):
-            shift
-            SQUASHFS_B="$1"
             shift
             ;;
         -f|--force)
@@ -230,25 +198,14 @@ dependencies=(
     [zcat]='gzip'
 )
 
-if [ "$ISO" ]; then
-    dependencies+=(
-        [xorriso]='xorriso'
-        [mkdosfs]='dosfstools'
-        [mcopy]='mtools'
-        [mkisofs]='genisoimage'
-        [grub-mkimage]='grub-common'
-        [mksquashfs]='squashfs-tools'
-    )
+if [ "$NTFS" ]; then
+    MKFS_IMAGES="mkfs.ntfs"
+    MKFS_ARGS='--quick -L'
+    dependencies[$MKFS_IMAGES]='ntfs-3g'
 else
-    if [ "$NTFS" ]; then
-        MKFS_IMAGES="mkfs.ntfs"
-        MKFS_ARGS='--quick -L'
-        dependencies[$MKFS_IMAGES]='ntfs-3g'
-    else
-        MKFS_IMAGES="mkfs.exfat"
-        MKFS_ARGS=-n
-        dependencies[$MKFS_IMAGES]='exfat-utils'
-    fi
+    MKFS_IMAGES="mkfs.exfat"
+    MKFS_ARGS=-n
+    dependencies[$MKFS_IMAGES]='exfat-utils'
 fi
 
 for command in "${!dependencies[@]}"; do
@@ -280,37 +237,27 @@ echo "  Installer for Windows: ${WINDOWS_TOOL:-latest release}"
 echo "                 Target: ${OUTPUT}"
 echo
 
-if [ "$ISO" ]; then
-    if [ -f "$OUTPUT" ] && [ ! "$FORCE" ]; then
-        echo "$OUTPUT already exists... aborting!" >&2
-        exit 1
-    fi
+if [ ! -e "$OUTPUT" ]; then
+    echo "$OUTPUT does not exist... aborting!" >&2
+    exit 1
+fi
 
-    OUTPUT_DIR=$(dirname "$OUTPUT")
-    mkdir -p "$OUTPUT_DIR"  &>/dev/null
-else
-    if [ ! -e "$OUTPUT" ]; then
-        echo "$OUTPUT does not exist... aborting!" >&2
-        exit 1
-    fi
+if [ ! -b "$OUTPUT" ]; then
+    echo "$OUTPUT is not a block device... aborting!" >&2
+    exit 1
+fi
 
-    if [ ! -b "$OUTPUT" ]; then
-        echo "$OUTPUT is not a block device... aborting!" >&2
-        exit 1
-    fi
+if grep -qs "$OUTPUT" /proc/mounts; then
+    # Protect against overwriting the device currently in use
+    echo "$OUTPUT is currently in use -- please unmount and try again" >&2
+    exit 1
+fi
 
-    if grep -qs "$OUTPUT" /proc/mounts; then
-        # Protect against overwriting the device currently in use
-        echo "$OUTPUT is currently in use -- please unmount and try again" >&2
+if [ ! "$FORCE" ]; then
+    read -p "Are you sure you want to overwrite all data on $OUTPUT? [y/N] "
+    response="${REPLY,,}" # to lower
+    if [[ ! "$response" =~ ^(yes|y)$ ]]; then
         exit 1
-    fi
-
-    if [ ! "$FORCE" ]; then
-        read -p "Are you sure you want to overwrite all data on $OUTPUT? [y/N] "
-        response="${REPLY,,}" # to lower
-        if [[ ! "$response" =~ ^(yes|y)$ ]]; then
-            exit 1
-        fi
     fi
 fi
 
@@ -348,79 +295,66 @@ check_exists "$WINDOWS_TOOL" "Windows tool"
 echo
 echo "Preparing $OUTPUT..."
 
-if [ "$ISO" ]; then
-    # Don't override an explicit $TMPDIR, but default to /var/tmp because /tmp
-    # is typically a tmpfs which is probably too small to hold the uncompressed
-    # image and squashfs image.
-    ISO_TMPDIR="$(mktemp -d -t eos-iso.XXXXXX -p "${TMPDIR:-/var/tmp}")"
-    DIR_EFI="$ISO_TMPDIR/efi"
-    DIR_IMAGES="$ISO_TMPDIR/images"
-    DIR_ESP="$ISO_TMPDIR/esp"
+# Erase any existing ISO9660 (0x8000 == 8 * 4096) or Joliet
+# (0x9000 == 9 * 4096) header on the disk. If you have written ISO image I
+# to disk A, overwrite disk A with this tool, write I to disk B, then try
+# to boot from B with A still plugged in, the "UUID" from the stale ISO9660
+# header on A is still read by the kernel and taken as the UUID for disk A
+# as a whole, and its BIOS boot partition too (for good measure). This
+# confuses eos-image-boot-setup into trying to mount a partition on disk A
+# rather than B.
+dd if=/dev/zero of="$OUTPUT" bs=4096 count=2 seek=8
+udevadm settle
 
-    # Just to be sure
-    mkdir "$DIR_EFI" "$DIR_IMAGES" "$DIR_ESP"
-else
-    # Erase any existing ISO9660 (0x8000 == 8 * 4096) or Joliet
-    # (0x9000 == 9 * 4096) header on the disk. If you have written ISO image I
-    # to disk A, overwrite disk A with this tool, write I to disk B, then try
-    # to boot from B with A still plugged in, the "UUID" from the stale ISO9660
-    # header on A is still read by the kernel and taken as the UUID for disk A
-    # as a whole, and its BIOS boot partition too (for good measure). This
-    # confuses eos-image-boot-setup into trying to mount a partition on disk A
-    # rather than B.
-    dd if=/dev/zero of="$OUTPUT" bs=4096 count=2 seek=8
-    udevadm settle
-
-    if [ "$MBR" ]; then
-        sfdisk --label dos "$OUTPUT" <<MBR_PARTITIONS
+if [ "$MBR" ]; then
+    sfdisk --label dos "$OUTPUT" <<MBR_PARTITIONS
 1 : type=7
 MBR_PARTITIONS
-        udevadm settle
-        partprobe "$OUTPUT"
-        PARTMAP=$(sfdisk --dump "$OUTPUT")
-        DEVICE_IMAGES=$(find_by_type "$PARTMAP" "7")
-    else
-        # https://en.wikipedia.org/wiki/GUID_Partition_Table#Partition_type_GUIDs
-        PARTITION_SYSTEM_GUID="c12a7328-f81f-11d2-ba4b-00a0c93ec93b"
-        PARTITION_BIOS_BOOT_GUID="21686148-6449-6E6F-744E-656564454649"
-        PARTITION_BASIC_DATA_GUID="ebd0a0a2-b9e5-4433-87c0-68b6b72699c7"
+    udevadm settle
+    partprobe "$OUTPUT"
+    PARTMAP=$(sfdisk --dump "$OUTPUT")
+    DEVICE_IMAGES=$(find_by_type "$PARTMAP" "7")
+else
+    # https://en.wikipedia.org/wiki/GUID_Partition_Table#Partition_type_GUIDs
+    PARTITION_SYSTEM_GUID="c12a7328-f81f-11d2-ba4b-00a0c93ec93b"
+    PARTITION_BIOS_BOOT_GUID="21686148-6449-6E6F-744E-656564454649"
+    PARTITION_BASIC_DATA_GUID="ebd0a0a2-b9e5-4433-87c0-68b6b72699c7"
 
-        # We want the data partition, "eoslive", to occupy all the space on the disk
-        # after the UEFI and BIOS boot partitions. But, we also want it to be numbered
-        # first: apparently Windows will only mount the partition numbered first,
-        # regardless of where it is on the disk.
-        #
-        # It is important that the offset of the BIOS boot partition matches that
-        # used in the Endless OS image builder, since it is embedded in the GRUB
-        # image.
-        sfdisk --label gpt "$OUTPUT" <<EFI_PARTITIONS
+    # We want the data partition, "eoslive", to occupy all the space on the disk
+    # after the UEFI and BIOS boot partitions. But, we also want it to be numbered
+    # first: apparently Windows will only mount the partition numbered first,
+    # regardless of where it is on the disk.
+    #
+    # It is important that the offset of the BIOS boot partition matches that
+    # used in the Endless OS image builder, since it is embedded in the GRUB
+    # image.
+    sfdisk --label gpt "$OUTPUT" <<EFI_PARTITIONS
 2 : start=2048, size=62MiB, type=$PARTITION_SYSTEM_GUID
 3 : size=1MiB, type=$PARTITION_BIOS_BOOT_GUID
 1 : name=eoslive, type=$PARTITION_BASIC_DATA_GUID
 EFI_PARTITIONS
-        udevadm settle
-        partprobe "$OUTPUT"
-        PARTMAP=$(sfdisk --dump "$OUTPUT")
-        DEVICE_IMAGES=$(find_by_type "$PARTMAP" "$PARTITION_BASIC_DATA_GUID")
-        DEVICE_EFI=$(find_by_type "$PARTMAP" "$PARTITION_SYSTEM_GUID")
-        DEVICE_BIOS=$(find_by_type "$PARTMAP" "$PARTITION_BIOS_BOOT_GUID")
-    fi
-
-    # Give udisks a chance to notice the new partitions
     udevadm settle
+    partprobe "$OUTPUT"
+    PARTMAP=$(sfdisk --dump "$OUTPUT")
+    DEVICE_IMAGES=$(find_by_type "$PARTMAP" "$PARTITION_BASIC_DATA_GUID")
+    DEVICE_EFI=$(find_by_type "$PARTMAP" "$PARTITION_SYSTEM_GUID")
+    DEVICE_BIOS=$(find_by_type "$PARTMAP" "$PARTITION_BIOS_BOOT_GUID")
+fi
 
-    if [ ! "$MBR" ]; then
-        mkfs.vfat -n efi "${DEVICE_EFI}"
-        partprobe "$OUTPUT"
-        udevadm settle
-        DIR_EFI=$(udisks_mount "$DEVICE_EFI")
-    fi
+# Give udisks a chance to notice the new partitions
+udevadm settle
 
-    $MKFS_IMAGES $MKFS_ARGS eoslive "${DEVICE_IMAGES}"
+if [ ! "$MBR" ]; then
+    mkfs.vfat -n efi "${DEVICE_EFI}"
     partprobe "$OUTPUT"
     udevadm settle
-    DIR_IMAGES=$(udisks_mount "$DEVICE_IMAGES")
+    DIR_EFI=$(udisks_mount "$DEVICE_EFI")
 fi
+
+$MKFS_IMAGES $MKFS_ARGS eoslive "${DEVICE_IMAGES}"
+partprobe "$OUTPUT"
+udevadm settle
+DIR_IMAGES=$(udisks_mount "$DEVICE_IMAGES")
 
 echo
 echo "Copying files"
@@ -452,101 +386,29 @@ VideoFiles=false
 AUTORUN_INF
 fi
 
-# attempt to avoid copy if input image is already compressed but fall back
-# gracefully if the image and tmpdir turn out to be different devices
-if [ "$OS_IMAGE" == "$OS_IMAGE_UNCOMPRESSED" ]; then
-    ln "$OS_IMAGE" "${DIR_IMAGES_ENDLESS}/endless.img" 2>/dev/null || true
-fi
-
-if [ ! -e "${DIR_IMAGES_ENDLESS}/endless.img" ]; then
-    "$EOS_WRITE_IMAGE" "$OS_IMAGE" "-" > "${DIR_IMAGES_ENDLESS}/endless.img"
-fi
+"$EOS_WRITE_IMAGE" "$OS_IMAGE" "-" > "${DIR_IMAGES_ENDLESS}/endless.img"
 
 echo
-echo "Finalizing image"
+echo "Finalizing"
 
-if [ "$ISO" ]; then
-
-    # Converting to squashfs
-    mksquashfs "${DIR_IMAGES_ENDLESS}/endless.img" "${DIR_IMAGES_ENDLESS}/endless.squash" \
-        -comp "$SQUASHFS_COMP" \
-        -b "$SQUASHFS_B"
-    rm -f "${DIR_IMAGES_ENDLESS}/endless.img"
-
-    if [ "$DELETE_OS_IMAGE" ]; then
-        rm -f "$OS_IMAGE"
-    fi
-
-    # Preparing for ESP
-    DIR_EFI_SIZE=$(du -s ${DIR_EFI} | cut -f1)
-    ESP_SIZE=$(( (${DIR_EFI_SIZE} + 1024) / 1024 * 1024 ))
-
-    # Create ESP and copy the EFI content
-    truncate -s ${ESP_SIZE}K ${DIR_ESP}/efi.img
-    mkdosfs ${DIR_ESP}/efi.img
-    mcopy -s -i ${DIR_ESP}/efi.img ${DIR_EFI}/EFI '::/'
-
-    # Unzip the ISO bootzip content
-    unzip -q -d "${DIR_IMAGES_ENDLESS}/grub/i386-pc/" "${BOOT_ZIP}" "iso/*"
-
-    VOLID=$(echo -n "$LABEL" | tr -cs '[A-Za-z0-9_]' '-')
-
-    # Generate the ISO image.
-    # Parameters found using https://dev.lovelyhq.com/libburnia/libisoburn/raw/master/frontend/grub-mkrescue-sed.sh
-    #
-    # export MKRESCUE_SED_MODE=mbr_only
-    # export MKRESCUE_SED_PROTECTIVE=no
-    # export MKRESCUE_SED_DEBUG=yes
-    #
-    # grub-mkrescue -o output.iso minimal_directory --xorriso=grub-mkrescue-sed.sh
-
-    xorriso -as mkisofs \
-	    -o ${OUTPUT} \
-	    -r -graft-points -no-pad \
-	    --sort-weight 0 / \
-	    --sort-weight 1 /endless \
-	    -b endless/grub/i386-pc/iso/eltorito.img \
-	    -no-emul-boot -boot-load-size 4 -boot-info-table --grub2-boot-info \
-	    --grub2-mbr ${DIR_IMAGES_ENDLESS}/grub/i386-pc/iso/boot_hybrid.img \
-	    -eltorito-alt-boot \
-	    -e --interval:appended_partition_2:all:: \
-	    -no-emul-boot \
-	    -append_partition 2 0xef ${DIR_ESP}/efi.img \
-	    -iso-level 3 \
-	    -joliet -joliet-long \
-	    -volid "$VOLID" \
-	    -publisher 'Endless Computers' \
-	    ${DIR_IMAGES}
-
-    # Change partition type from 0x83 to 0x00
-    printf "\x00" | dd of=${OUTPUT} bs=1 count=1 seek=450 conv=notrunc
+udisks_unmount "$DEVICE_IMAGES"
+if [ ! "$MBR" ]; then
+    udisks_unmount "$DEVICE_EFI"
 fi
 
-echo
-echo "Cleaning up"
-
-if [ "$ISO" ]; then
-    rm -fr ${ISO_TMPDIR}
+if [ "$MBR" ]; then
+    # Bootstrap code, which will jump to sector 1
+    unzip -q -p "${BOOT_ZIP}" "ntfs/boot.img" | dd of="${OUTPUT}" bs=446 count=1
+    udevadm settle  # udev recreates device files after any write to the device
+    # The rest of GRUB goes after the MBR and before the first partition.
+    unzip -q -p "${BOOT_ZIP}" "ntfs/core.img" | dd of="${OUTPUT}" bs=512 seek=1
 else
-    udisks_unmount "$DEVICE_IMAGES"
-    if [ ! "$MBR" ]; then
-        udisks_unmount "$DEVICE_EFI"
-    fi
-
-    if [ "$MBR" ]; then
-        # Bootstrap code, which will jump to sector 1
-        unzip -q -p "${BOOT_ZIP}" "ntfs/boot.img" | dd of="${OUTPUT}" bs=446 count=1
-        udevadm settle  # udev recreates device files after any write to the device
-        # The rest of GRUB goes after the MBR and before the first partition.
-        unzip -q -p "${BOOT_ZIP}" "ntfs/core.img" | dd of="${OUTPUT}" bs=512 seek=1
-    else
-        # Bootstrap code, built to jump to the offset of BIOS boot partition
-        unzip -q -p "${BOOT_ZIP}" "live/boot.img" | dd of="${OUTPUT}" bs=446 count=1
-        udevadm settle  # udev recreates device files after any write to the device
-        # The rest of GRUB goes into a dedicated BIOS-boot partition
-        unzip -q -p "${BOOT_ZIP}" "live/core.img" | dd of="${DEVICE_BIOS}" bs=512
-    fi
-
-    udevadm settle
-    sync
+    # Bootstrap code, built to jump to the offset of BIOS boot partition
+    unzip -q -p "${BOOT_ZIP}" "live/boot.img" | dd of="${OUTPUT}" bs=446 count=1
+    udevadm settle  # udev recreates device files after any write to the device
+    # The rest of GRUB goes into a dedicated BIOS-boot partition
+    unzip -q -p "${BOOT_ZIP}" "live/core.img" | dd of="${DEVICE_BIOS}" bs=512
 fi
+
+udevadm settle
+sync

--- a/eos-tech-support/eos-write-live-image
+++ b/eos-tech-support/eos-write-live-image
@@ -10,12 +10,12 @@ set -o pipefail
 # the image partition. Additional images copied to the image partition will be
 # detected by the installer, but will not be bootable.
 
-EOS_WRITE_IMAGE=$(dirname $0)/eos-write-image
-if [ ! -f $EOS_WRITE_IMAGE ]; then
+EOS_WRITE_IMAGE=$(dirname "$0")/eos-write-image
+if [ ! -f "$EOS_WRITE_IMAGE" ]; then
     EOS_WRITE_IMAGE='eos-write-image'
 fi
-EOS_DOWNLOAD_IMAGE=$(dirname $0)/eos-download-image
-if [ ! -f $EOS_DOWNLOAD_IMAGE ]; then
+EOS_DOWNLOAD_IMAGE=$(dirname "$0")/eos-download-image
+if [ ! -f "$EOS_DOWNLOAD_IMAGE" ]; then
     EOS_DOWNLOAD_IMAGE='eos-download-image'
 fi
 
@@ -45,7 +45,8 @@ LABEL=
 DEBUG=
 
 usage() {
-    local SELF="$(basename "$0")"
+    local SELF
+    SELF=$(basename "$0")
     cat <<EOF
 Usage:
     $SELF [options] OUTPUT
@@ -89,7 +90,7 @@ function udisks_mount() {
         echo "Failed to mount $1" >&2
         exit 1
     fi
-    echo $MOUNT_POINT
+    echo "$MOUNT_POINT"
 }
 
 function udisks_unmount() {
@@ -174,7 +175,7 @@ if [ $# -ne 1 ] ; then
     if [ $# -lt 1 ] ; then
         echo "Error: missing OUTPUT" >&2
     else
-        echo "Error: extra arguments after OUTPUT: $@" >&2
+        echo "Error: extra arguments after OUTPUT:" "$@" >&2
     fi
     echo >&2
     usage >&2
@@ -254,7 +255,7 @@ if grep -qs "$OUTPUT" /proc/mounts; then
 fi
 
 if [ ! "$FORCE" ]; then
-    read -p "Are you sure you want to overwrite all data on $OUTPUT? [y/N] "
+    read -r -p "Are you sure you want to overwrite all data on $OUTPUT? [y/N] "
     response="${REPLY,,}" # to lower
     if [[ ! "$response" =~ ^(yes|y)$ ]]; then
         exit 1


### PR DESCRIPTION
ISO generation now lives in the image builder.  It was never possible to run this mode on an unconverted Endless OS system, since several of the dependencies are not included in the ostree.

I also tidied up a few things I noticed along the way.

https://phabricator.endlessm.com/T17203