### PR TITLE
convert-system-qa: set core_pattern immediately

### DIFF
--- a/eos-tech-support/eos-convert-system-qa
+++ b/eos-tech-support/eos-convert-system-qa
@@ -70,6 +70,7 @@ fi
 # Enable systemd coredumps storage
 echo "Enabling systemd coredumps processing and storage"
 echo "kernel.core_pattern=|/lib/systemd/systemd-coredump %p %u %g %s %t %c %e" > /etc/sysctl.d/50-coredump.conf
+sysctl -p /etc/sysctl.d/50-coredump.conf
 
 # Set metrics env to dev.
 if $METRICS; then


### PR DESCRIPTION
Previously, systemd-coredump would be enabled on the next boot, but not
during the current boot. I hit an eos-updater SIGSEGV while pulling an
update after running `eos-convert-system-qa --ostree` and it would have
been nice to get a core dump.