### PR TITLE
ostree-fix-repo: Improve check for partial commits

### DIFF
--- a/eos-tech-support/eos-fix-ostree-repo
+++ b/eos-tech-support/eos-fix-ostree-repo
@@ -201,17 +201,18 @@ def pull_partial_refs(repo):
     # Look for any partial refs and re-pull them.
     _, all_refs = repo.list_refs()
     for refspec, checksum in all_refs.items():
+        _, remote, ref = OSTree.parse_refspec(refspec)
+        if remote is None:
+            # Don't bother pulling local refs. Only the ostree deploys
+            # are local, and as long as they're marked partial, they can
+            # be updated later.
+            continue
+
         _, commit, state = repo.load_commit(checksum)
         if state != OSTree.RepoCommitState.REPO_COMMIT_STATE_PARTIAL:
             continue
 
         # Try to pull the full commit again.
-        _, remote, ref = OSTree.parse_refspec(refspec)
-        if remote is None:
-            # If there's no remote, assume it's an ostree ref and use
-            # "eos" as the remote.
-            print('No remote for ref', ref, 'assuming "eos"')
-            remote = 'eos'
         print('Pulling', checksum, 'commit from', remote, 'for', ref)
         pull_commit(repo, remote, checksum, full=True)
 

--- a/eos-tech-support/eos-fix-ostree-repo
+++ b/eos-tech-support/eos-fix-ostree-repo
@@ -166,13 +166,29 @@ def mark_commits_partial(repo):
             print('Commit', checksum, 'already marked as partial')
             continue
 
+        mark_partial = False
         try:
-            repo.traverse_commit(checksum, 0)
+            # If a dirtree is missing, traverse_commit will fail with
+            # G_IO_ERROR_NOT_FOUND.
+            _, reachable_objects = repo.traverse_commit(checksum, 0)
+
+            # Unfortunately, it doesn't check that the leaves (dirmeta
+            # and files) exist, so we need to do that manually. In case
+            # that behavior ever changes, just check that all the
+            # reachable objects exist.
+            #
+            # https://github.com/ostreedev/ostree/issues/1222
+            for commit_obj in reachable_objects:
+                if commit_obj not in all_objects:
+                    mark_partial = True
+                    break
         except GLib.Error as err:
             if not err.matches(Gio.io_error_quark(),
                                Gio.IOErrorEnum.NOT_FOUND):
                 raise
+            mark_partial = True
 
+        if mark_partial:
             print('Marking commit', checksum, 'as partial')
             commit_partial_path = os.path.join(repo_path, 'state',
                                                checksum + '.commitpartial')

--- a/eos-tech-support/eos-fix-ostree-repo
+++ b/eos-tech-support/eos-fix-ostree-repo
@@ -42,6 +42,7 @@ processes that have the repository open are killed.
 """
 
 from argparse import ArgumentParser
+from fnmatch import fnmatch
 import gi
 gi.require_version('OSTree', '1.0')
 from gi.repository import GLib, Gio, OSTree
@@ -139,7 +140,7 @@ def fix_dangling_refs(repo):
                                Gio.IOErrorEnum.NOT_FOUND):
                 raise
 
-            # Try to pull it the commit metadata again.
+            # Try to pull the commit metadata again.
             _, remote, ref = OSTree.parse_refspec(refspec)
             if remote is None:
                 # If there's no remote, assume it's an ostree ref and
@@ -206,6 +207,14 @@ def pull_partial_refs(repo):
             # Don't bother pulling local refs. Only the ostree deploys
             # are local, and as long as they're marked partial, they can
             # be updated later.
+            continue
+
+        # If this is an app or runtime locale, it's intentionally
+        # partial since only the relevant subpaths are pulled. Skip it
+        # to not use up extra bandwidth and disk space.
+        if fnmatch(ref, '*/*.Locale/*/*'):
+            print('Skipping intentionally partial Locale commit',
+                  refspec, checksum)
             continue
 
         _, commit, state = repo.load_commit(checksum)

--- a/eos-tech-support/eos-fix-ostree-repo
+++ b/eos-tech-support/eos-fix-ostree-repo
@@ -196,29 +196,16 @@ def mark_commits_partial(repo):
                 pass
 
 
-def pull_partial_commits(repo):
+def pull_partial_refs(repo):
     """Try to fully restore any partial referenced commits"""
-    # Make a reverse mapping of commit to ref
+    # Look for any partial refs and re-pull them.
     _, all_refs = repo.list_refs()
-    commit_refs = dict([(v, k) for k, v in all_refs.items()])
-
-    # Look for any commits marked partial. If they're referenced, pull
-    # them.
-    _, all_objects = repo.list_objects(OSTree.RepoListObjectsFlags.ALL, None)
-    for objname in all_objects:
-        checksum, objtype = OSTree.object_name_deserialize(objname)
-        if objtype != OSTree.ObjectType.COMMIT:
-            continue
+    for refspec, checksum in all_refs.items():
         _, commit, state = repo.load_commit(checksum)
         if state != OSTree.RepoCommitState.REPO_COMMIT_STATE_PARTIAL:
             continue
 
-        # See if there's a ref to this commit
-        refspec = commit_refs.get(checksum)
-        if refspec is None:
-            continue
-
-        # Try to pull it the commit metadata again.
+        # Try to pull the full commit again.
         _, remote, ref = OSTree.parse_refspec(refspec)
         if remote is None:
             # If there's no remote, assume it's an ostree ref and use
@@ -268,9 +255,9 @@ def main():
     # Next, traverse all commits to mark any as partial
     mark_commits_partial(repo)
 
-    # Finally, try to completely pull in any partial commits so there
-    # are no longer any missing objects
-    pull_partial_commits(repo)
+    # Finally, try to completely pull in any partial referenced commits
+    # so there are no longer any missing objects
+    pull_partial_refs(repo)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Unfortunately, the script was only catching when a `dirtree` object was missing, not a `dirmeta` or `file` object. That meant that in many cases the commit wasn't being marked as partial and the script carried on without refetching missing objects.

I also added one more commit to skip pulling full Locale commits as flatpak intentionally does partial pulls of those. Pulling the full commit would just waste bandwidth and disk space.

I tested this in a VM where I deleted all types of missing objects. After running the script, `ostree fsck` succeeded, I was able to update to update the platform, and I was able to install an app.

https://phabricator.endlessm.com/T18946