### PR TITLE
Explicitly install libglx-mesa0

### DIFF
--- a/base-depends
+++ b/base-depends
@@ -19,12 +19,14 @@ libcanberra-pulse
 libcaribou-gtk-module
 libcaribou-gtk3-module
 # Mali used on arm
+libegl-mesa0 [!armhf]
 libegl1 [!armhf]
 # Mali used on arm
 libgles2 [!armhf]
 libglib2.0-data
 libglu1-mesa [!armhf]
 libgl1-nvidia-glvnd-glx [!armhf]
+libglx-mesa0
 libnss-altfiles
 libnss-myhostname
 locales


### PR DESCRIPTION
With GLVND, we have libglx0 provided by libglvnd, which is provides de
API and dispatch library for applications. It depends on
'libglx-mesa0 | libglx-vendor', and libglx-vendor is provided by both
libglx-mesa0 and libglx-nvidia0.

After adding the nvidia proprietary drivers, we are pulling
libglx-nvidia0 as a dependency of libgl1-nvidia-glvnd-glx, so we could
fall into a situation where libglx-mesa0 is missing because libglx0's
dependency is already satisfied by libglx-vendor through libglx-nvidia0.
This has been seen on eos-converted systems, but on on OSTree-based
systems so far, although that was probably pure luck.

Explicitly installing libglx-mesa0 should guarantee we always have both
libraries installed.

https://phabricator.endlessm.com/T18579