### PR TITLE
eos-diagnostics: reveal created file, be friendlier

### DIFF
--- a/eos-tech-support/eos-diagnostics
+++ b/eos-tech-support/eos-diagnostics
@@ -645,7 +645,16 @@ function dumpDiagnostics(filename, verboseFlag) {
     } else {
         try {
             GLib.file_set_contents(filename, fullDump);
-            log('Saved to ' + filename);
+            print('Endless OS Diagnostics file saved as:')
+            print(filename);
+            print('Please send that file (not this message!) to the Endless Community or Support.');
+
+            // pop up a new Nautilus window, with the file pre-selected
+            try {
+                GLib.spawn_command_line_async('nautilus --new-window --select ' + filename);
+            } catch (e) {
+                // oh well, never mind
+            }
         } catch (e) {
             log('Can\'t save diagnostic file to ' + filename + ': ' + e.message);
         }


### PR DESCRIPTION
Before:

    Gjs-Message: JS LOG: Saved to /sysroot/home/wjt/eos-diagnostic-171103_144228_UTC
    +0000.txt

(This message is too long for the default width of the terminal, even
with my short username; I have indicated how the line is wrapped in
practice.)

After:

    Endless OS Diagnostics file saved as:
    /sysroot/home/wjt/eos-diagnostic-171103_144325_UTC+0000.txt
    Please send that file (not this message!) to the Endless Community or Support.

and Nautilus pops up, with the file already highlighted.

I tried to use `Gtk.RecentManager.get_default().add_item(filename)` to add
it to the Recent tab in Nautilus and the file picker, but no dice.

https://phabricator.endlessm.com/T19833