### PR TITLE
os-depends: add nvidia-driver-bin

### DIFF
--- a/os-depends
+++ b/os-depends
@@ -52,6 +52,7 @@ module-init-tools
 net-tools
 network-manager
 network-manager-gnome
+nvidia-driver-bin [!armhf]
 nvidia-kernel-drivers [!armhf]
 ntp
 openssh-client


### PR DESCRIPTION
This is needed to enable some app-specific workarounds, fixing a
gnome-shell flicker on Asus GL702VMK.

https://phabricator.endlessm.com/T19768