### PR TITLE
eos-write-installer: Check for pv dependency

### DIFF
--- a/eos-tech-support/eos-write-installer
+++ b/eos-tech-support/eos-write-installer
@@ -96,6 +96,7 @@ declare -A dependencies
 dependencies=(
     [dd]='coreutils'
     [mkfs.exfat]='exfat-utils'
+    [pv]='pv'
     [xzcat]='xz-utils'
     [zcat]='gzip'
 )


### PR DESCRIPTION
pv is used, so warn the user if it's not installed.