### PR TITLE
Conflict on WebKit packages with an epoch set

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -11,7 +11,9 @@ Package: eos-core
 Architecture: any
 Replaces: endless-core
 Provides: endless-core
-Conflicts: endless-core
+Conflicts: endless-core,
+           libwebkit2gtk-4.0-37 (>= 1:2.18.4),
+           libjavascriptcoregtk-4.0-18 (>= 1:2.18.4)
 Depends: ${misc:Depends}, ${eos:Depends}
 Description: Target packages of the Endless distribution
  This package depends on all packages required for the Endless OS core images
@@ -22,6 +24,8 @@ Description: Target packages of the Endless distribution
 Package: eos-platform-runtime
 Architecture: any
 Depends: ${misc:Depends}, ${eos:Depends}
+Conflicts: libwebkit2gtk-4.0-37 (>= 1:2.18.4),
+           libjavascriptcoregtk-4.0-18 (>= 1:2.18.4)
 Description: Target packages of the Endless platform runtime
  This metapackage depends on all packages required for the Endless
  platform runtime.
@@ -29,6 +33,8 @@ Description: Target packages of the Endless platform runtime
 Package: eos-sdk-runtime
 Architecture: any
 Depends: ${misc:Depends}, ${eos:Depends}
+Conflicts: libwebkit2gtk-4.0-37 (>= 1:2.18.4),
+           libjavascriptcoregtk-4.0-18 (>= 1:2.18.4)
 Description: Target packages of the Endless SDK runtime
  This metapackage depends on all packages required for the Endless SDK
  runtime.


### PR DESCRIPTION
Starting with WebKit2GTK 2.18.4, we're getting rid of the epoch
added to WebKit packages since version 2.6.2, so make an explicit
conflict here so that such versions are never pulled for OSTree
based images, as well as to warn "users" of converted systems that
manual intervention (downgrading from 1:2.18.3 to 2.18.4) is required.

https://phabricator.endlessm.com/T20629