### PR TITLE
core: remove btrfs-tools

### DIFF
--- a/eos-core-depends
+++ b/eos-core-depends
@@ -11,7 +11,6 @@ apt-utils
 avahi-daemon
 bluez-obexd
 brasero
-btrfs-tools
 cdrdao
 cheese
 chromium-browser


### PR DESCRIPTION
Endless OS does not use btrfs.

https://phabricator.endlessm.com/T20709