### PR TITLE
os-depends: drop xkb-data-i18n

### DIFF
--- a/os-depends
+++ b/os-depends
@@ -82,7 +82,6 @@ wpasupplicant
 xauth
 xdg-user-dirs
 xdg-user-dirs-gtk
-xkb-data-i18n
 xserver-xorg
 xserver-xorg-input-libinput
 # Some of these are really specific to x86, but just keep them off of arm for now


### PR DESCRIPTION
This is an ubuntu-specific package but we are switching to the
Debian version of xkeyboard-config, where these i18n data files are
included in the regular xkb-data package which we already ship.

https://phabricator.endlessm.com/T20508