### PR TITLE
core: remove btrfs-tools

### DIFF
--- a/eos-core-depends
+++ b/eos-core-depends
@@ -16,7 +16,6 @@ bluez-obexd
 bogofilter
 brasero
 brasero-cdrkit
-btrfs-tools
 cdrdao
 cheese
 chromium-browser


### PR DESCRIPTION
Endless OS does not use btrfs.

This is a re-application of ef61b8b which was inadventently reverted by
15b5eb8.

https://phabricator.endlessm.com/T20709