### PR TITLE
eos-enable-coredumps: Set default `ulimit -c` value for systemd units

### DIFF
--- a/eos-tech-support/eos-enable-coredumps
+++ b/eos-tech-support/eos-enable-coredumps
@@ -35,6 +35,7 @@ fi
 CONF_FILENAME="99-coredump.conf"
 SYSCTL_CONF_FILE="${SYSCONFDIR}/sysctl.d/${CONF_FILENAME}"
 LIMITS_CONF_FILE="${SYSCONFDIR}/security/limits.d/${CONF_FILENAME}"
+SYSTEM_CONF_FILE="${SYSCONFDIR}/systemd/system.conf.d/${CONF_FILENAME}"
 
 # Enable coredumps
 mkdir -p $(dirname "${LIMITS_CONF_FILE}")
@@ -49,3 +50,13 @@ mkdir -p $(dirname "${SYSCTL_CONF_FILE}")
 echo "Enabling systemd coredumps processing and storage"
 echo "kernel.core_pattern=|/lib/systemd/systemd-coredump %p %u %g %s %t %c %e" > "${SYSCTL_CONF_FILE}"
 sysctl -p "${SYSCTL_CONF_FILE}"
+
+# Remove coredump size limits for all systemd-controlled processes by default.
+# Note that this won’t override explicit LimitCORE= values in individual unit files.
+mkdir -p $(dirname "${SYSTEM_CONF_FILE}")
+echo "Removing coredump size limits for systemd units"
+cat <<EOF > "${SYSTEM_CONF_FILE}"
+[Manager]
+# Do not limit coredumps by default
+DefaultLimitCORE=infinity
+EOF


### PR DESCRIPTION
Even if systemd-coredump is enabled, the default coredump size limit for
all systemd units is not infinite, and this prevents things like
eos-updater successfully dumping core, with the message:

   systemd-coredump[1664]: Resource limits disable core dumping for
   process 1573 (eos-updater).

This is frustrating.

Fix it by having eos-enable-coredumps add a systemd configuration file
which ups the default `ulimit -c` value for units to infinity.

See:
https://www.freedesktop.org/software/systemd/man/systemd-system.conf.html
and
https://lists.freedesktop.org/archives/systemd-devel/2013-February/009174.html.

Signed-off-by: Philip Withnall <withnall@endlessm.com>