### PR TITLE
defaults: Associate GNOME Software with ostree repos

### DIFF
--- a/debian/defaults.list
+++ b/debian/defaults.list
@@ -351,3 +351,4 @@ application/x-deb=com.endlessm.Gates.LinuxPackage.desktop
 application/x-rpm=com.endlessm.Gates.LinuxPackage.desktop
 application/x-source-rpm=com.endlessm.Gates.LinuxPackage.desktop
 text/x-processing=org.processing.App.desktop
+x-content/ostree-software=gnome-software-local-file.desktop


### PR DESCRIPTION
This patch sets GNOME Software as the default application for opening
ostree repos in removable drives. It should result in GNOME Software
opening by default when when a USB containing an ostree repo is
inserted.

https://phabricator.endlessm.com/T16950