### PR TITLE
eos-convert-system: do not use rename(1)

### DIFF
--- a/eos-tech-support/eos-convert-system
+++ b/eos-tech-support/eos-convert-system
@@ -129,8 +129,12 @@ mkdir -p /var/log/journal
 eos-enable-coredumps /sysroot/etc
 
 # Put the kernels/initramfs in the expected place by Debian
-cp -pax ${OSTREE_DEPLOY_CURRENT}/boot/{vmlinuz,initramfs}*  /boot
-rename 's/-\w*$//g,s/initramfs/initrd\.img/g' /boot/{vmlinuz,init}*
+for orig in ${OSTREE_DEPLOY_CURRENT}/boot/{vmlinuz,initramfs}*; do
+  new="${orig##*/}"
+  new="${new%-*}"
+  new="${new/initramfs/initrd.img}"
+  cp -pax "$orig" "/boot/$new"
+done
 
 if [ -L /boot/uEnv.txt ] ; then 
   # Running on ARM


### PR DESCRIPTION
When launched, this program prints the following warning:

> Deprecated program in use: rename as shipped with the Debian perl
> package will be removed after the release of stretch. Please install
> the separate 'rename' package which will provide the same command.

Rather than pull in this extra dependency just for the benefit of this
script, replace it with a few rounds of Bash parameter expansion.

https://phabricator.endlessm.com/T21179