### PR TITLE
eos-diagnostics: remove stray argument to GLib.spawn_sync()

### DIFF
--- a/eos-tech-support/eos-diagnostics
+++ b/eos-tech-support/eos-diagnostics
@@ -388,7 +388,7 @@ function collectPrintersInfo() {
         let envp = ['LANG=C'];
         let [res, stdout, stderr, exitStatus] = GLib.spawn_sync(null, argv, envp,
                                                                 GLib.SpawnFlags.DEFAULT,
-                                                                null, null);
+                                                                null);
         output += stdout;
     } catch (e) {
         output += 'error ocurred querying CUPS status: ' + e + '\n';


### PR DESCRIPTION
The 5 in parameters are working_directory, argv, envp, flags and
child_setup.  The 6th argument in C is user_data for the child_setup()
function but this is not applicable from JS.

https://phabricator.endlessm.com/T21220