### PR TITLE
eos-core-depends: Add libnss-systemd

### DIFF
--- a/eos-core-depends
+++ b/eos-core-depends
@@ -159,6 +159,8 @@ libmagickcore-6.q16-3-extra
 libmtp-runtime
 # For DNS lookup of .local domains
 libnss-mdns
+# For NSS lookup of users and groups created by units with DynamicUser=
+libnss-systemd
 # For auto-unlocking keyrings
 libpam-gnome-keyring
 libreoffice


### PR DESCRIPTION
This is a recommends of systemd-sysv, and it is needed so users and
groups created by units with DynamicUser= can be resolved by NSS.

Installing this package automatically adds the module to
/etc/nsswitch.conf.

https://phabricator.endlessm.com/T21201