### PR TITLE
os-depends: Add X fbdev driver

### DIFF
--- a/os-depends
+++ b/os-depends
@@ -99,6 +99,7 @@ xserver-xorg
 xserver-xorg-input-libinput
 # Some of these are really specific to x86, but just keep them off of arm for now
 xserver-xorg-video-amdgpu [!armhf]
+xserver-xorg-video-fbdev [!armhf]
 xserver-xorg-video-intel [!armhf]
 xserver-xorg-video-nouveau [!armhf]
 xserver-xorg-video-nvidia [!armhf]


### PR DESCRIPTION
Found xserver-xorg-video-fbdev - X.Org X server -- fbdev display driver is
missed in the master image.  The driver is needed for efifb.
If this is missed, the X will be black screen with the nouveau driver which goes
with parameters noaccel=1 modeset=0

Therfore, we need to add fbdev back.

https://phabricator.endlessm.com/T21555