### PR TITLE
Stress mem tools

### DIFF
--- a/eos-tech-support/README.md
+++ b/eos-tech-support/README.md
@@ -46,3 +46,8 @@ $ eos-user-stress-test medium
 ```
 
 For "heavy" stress, follow this with `eos-user-stress-test heavy`.
+
+eos-sysmem-sampler
+==================
+Continuously samples the various memory stats of the system and prints them out
+in a format for easy pasting into a spreadsheet.

--- a/eos-tech-support/README.md
+++ b/eos-tech-support/README.md
@@ -51,3 +51,18 @@ eos-sysmem-sampler
 ==================
 Continuously samples the various memory stats of the system and prints them out
 in a format for easy pasting into a spreadsheet.
+
+eos-procmem-sample
+==================
+Sums up the total PSS and RSS memory used by each process, collated by command.
+So, if there are two chrome processes using A and B KiB of PSS, respectively,
+the output will show a single row for "chrome" with a PSS value of A+B (KiB).
+
+PSS memory is a measure of memory used with each shared page of memory divided
+by the number of processes sharing it. This gives a better idea of how much
+memory each process is responsible for than RSS (which over-counts shared
+memory). Thus, processes which share a lot of memory look better compared by PSS
+than RSS.
+
+This command has to be run as root (eg, by running it through `sudo`) since it
+gets stats for all users' processes, including root.

--- a/eos-tech-support/README.md
+++ b/eos-tech-support/README.md
@@ -1,0 +1,48 @@
+eos-user-stress-test
+====================
+`eos-user-stress-test` is meant to be a reproducible simulation of user-based
+stressing of a system. It should always be realistic to how we expect an average
+user (see note below) to use the system. Testing for specific user profiles
+should be done in a different test component as this one is focused on ways most
+users might easily stress a system.
+
+Specifically, we expect users to:
+* launch apps by clicking icons (or hitting enter after searching on the
+  desktop)
+* fail to close apps proactively
+* open browser tabs without consideration of performance implications
+* fail to close browser tabs proactively
+* install apps from the App Center, possibly triggering as many as a dozen
+  installs before the first completes (in the case they're new to and excited
+  about the possibilities of the platform)
+* in general, not consider performance implications of their actions
+
+We expect users NOT to:
+* open a terminal
+* be malicious (this is simulating them using their own computer, after all)
+* do things to specifically stress the system, like:
+    * launch tens of apps at once (several at once might be reasonable though)
+    * open tens of browser tabs at once (though they might accumulate slowly
+      over time)
+    * launch fork bombs
+
+Usage
+=======
+`eos-user-stress-test` defines multiple "levels" of stress with each level
+adding more and different apps and websites to the current system load.
+
+Each level is meant to be triggered cumulatively. So, to get a system to
+"medium" stress, you would run:
+
+```
+$ eos-user-stress-test light
+```
+
+(possibly wait for the system to settle)
+
+```
+$ eos-user-stress-test medium
+
+```
+
+For "heavy" stress, follow this with `eos-user-stress-test heavy`.

--- a/eos-tech-support/eos-procmem-sample
+++ b/eos-tech-support/eos-procmem-sample
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+declare -A rss_sums
+declare -A pss_sums
+
+if [ $EUID != 0 ]; then
+    echo "permission denied: must be run as root" >&2
+    exit 1
+fi
+
+for pid in $(ps -ef | awk '{print $2}'); do
+    if [ -f /proc/$pid/smaps ]; then
+        cmd=$(cat /proc/$pid/comm)
+        rss=$(awk 'BEGIN {i=0} /^Rss/ {i = i + $2} END {print i}' \
+                /proc/$pid/smaps)
+        pss=$(awk 'BEGIN {i=0} /^Pss/ {i = i + $2} END {print i}' \
+                /proc/$pid/smaps)
+
+        rss_sums[$cmd]=$((${rss_sums[$cmd]} + $rss))
+        pss_sums[$cmd]=$((${pss_sums[$cmd]} + $pss))
+    fi
+done
+
+for k in ${!rss_sums[@]}; do
+    output=$(echo "$output\n$k\t${pss_sums[$k]}\t${rss_sums[$k]}")
+done
+
+# PSS is the "proportional" set size. In this measure, each shared page size is
+# divided by the number of processes sharing that page, to avoid the
+# double-counting you get with RSS. Thus, PSS values are a fairer measure of
+# memory usage than RSS for processes that heavily share their memory (like
+# Xorg)
+
+echo -e "process name\tPSS (KiB)\tRSS (KiB)"
+# print results sorted by PSS
+echo -e "$output" | sort -rnk 2

--- a/eos-tech-support/eos-sysmem-sampler
+++ b/eos-tech-support/eos-sysmem-sampler
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+echo -en "time\tphys total\tphys free\tphys used\tphys buff/cache\t"
+echo -en "phys avail\tswap total\tswap free\tswap used"
+echo
+
+while : ; do
+    # populate an array with the system memory summary lines from `free`
+    mapfile -t lines < <(free | egrep '^(Mem|Swap)')
+
+    time=$(date +%s)
+
+    phys_total=$(echo ${lines[0]} | cut -d ' ' -f 2)
+    phys_used=$(echo ${lines[0]} | cut -d ' ' -f 3)
+    phys_free=$(echo ${lines[0]} | cut -d ' ' -f 4)
+    phys_buff=$(echo ${lines[0]} | cut -d ' ' -f 6)
+    phys_avail=$(echo ${lines[0]} | cut -d ' ' -f 7)
+
+    swap_total=$(echo ${lines[1]} | cut -d ' ' -f 2)
+    swap_used=$(echo ${lines[1]} | cut -d ' ' -f 3)
+    swap_free=$(echo ${lines[1]} | cut -d ' ' -f 4)
+
+    echo -en "${time}\t${phys_total}\t${phys_free}\t${phys_used}\t"
+    echo -en "${phys_buff}\t${phys_avail}\t${swap_total}\t"
+    echo -en "${swap_free}\t${swap_used}"
+    echo
+
+    sleep 1
+done

--- a/eos-tech-support/eos-user-stress-test
+++ b/eos-tech-support/eos-user-stress-test
@@ -1,0 +1,130 @@
+#!/bin/bash
+
+set -euo pipefail
+
+DATA_FILES_URL=https://github.com/endlessm/eos-qa-test-files/archive/master.zip
+DATA_FILES_BASEDIR=~/eos-qa-test-files-master
+DATA_FILES_ZIP=${DATA_FILES_BASEDIR}.zip
+DATA_FILES=${DATA_FILES_BASEDIR}/user-tests
+SLEEP_APP_LAUNCH=30
+SLEEP_URL_LAUNCH=10
+
+command=""
+if [ $# -gt 0 ]; then
+        command=$1
+fi
+
+check_dep_flatpak() {
+    # relies on set -e
+    flatpak info $1 > /dev/null
+}
+
+check_deps_common() {
+    if [ ! -e $DATA_FILES ]; then
+        echo "missing data files at $DATA_FILES; attempting to download"
+        wget -O ${DATA_FILES_ZIP} ${DATA_FILES_URL}
+        unzip -d $(dirname ${DATA_FILES_BASEDIR}) ${DATA_FILES_ZIP}
+        if [ $? -ne 0 ]; then
+            echo >&2 "failed to extract test files from archive"
+            exit 1
+        fi
+    fi
+}
+
+check_deps_light() {
+    check_deps_common
+    check_dep_flatpak "com.endlessm.animals.en"
+}
+
+check_deps_medium() {
+    check_deps_common
+}
+
+check_deps_heavy() {
+    check_deps_common
+    check_dep_flatpak "org.gimp.Gimp"
+}
+
+check_deps() {
+    check_deps_light
+    check_deps_medium
+    check_deps_heavy
+}
+
+command_launch() {
+    cmd="$1"
+    shift
+
+    $cmd $@ &
+    # wait to simulate a (somewhat-patient) user launching an app then waiting
+    # some time before doing any other work (like launching other apps)
+    #
+    # NOTE: a more-realistic scenario would be waiting until the app appears to
+    # be responsive, use it for a while, then launch another app. But that would
+    # be fairly complex to simulate as an app's "apparent" readiness to be used
+    # depends on the app and is probably not readily detected in software.
+    sleep $SLEEP_APP_LAUNCH
+}
+
+url_launch() {
+    gio open $1 &
+
+    # see note above for command_launch; this wait time is shorter as users seem
+    # likely to wait much less time between opening new tabs
+    sleep_time=$SLEEP_URL_LAUNCH
+
+    if [ $browser_launched -eq 0 ]; then
+        # on the first URL launch of this script's run, assume the browser is
+        # launching and give it more time.
+        #
+        # this isn't a perfect check but the browser (or any apps but the
+        # terminal and maybe system monitor) shouldn't be running at the start
+        # of this script under normal use.
+        sleep_time=$SLEEP_APP_LAUNCH
+        browser_launched=1
+    fi
+
+    sleep $sleep_time
+}
+
+browser_launched=0
+
+# note that this implicitly depends upon EOS >= 3.0 for the `gio` command and
+# apps being packaged as Flatpaks
+case $command in
+    check)
+        check_deps
+        echo "all dependencies fulfilled"
+        ;;
+    light)
+        check_deps_light
+        command_launch flatpak run com.endlessm.animals.en
+        command_launch lowriter --norestore ${DATA_FILES}/chicken.odt
+        url_launch https://www.google.com/search?q=chicken
+        url_launch https://www.youtube.com/watch?v=vgUzdb3S2uA
+        url_launch https://codecombat.com/
+        ;;
+    medium)
+        check_deps_medium
+        command_launch rhythmbox
+        command_launch localc --norestore ${DATA_FILES}/random-data.ods
+        url_launch https://news.google.com/
+        url_launch http://www.espn.com/
+        url_launch http://www.maxgames.com/
+        ;;
+    heavy)
+        check_deps_heavy
+        command_launch shotwell
+        command_launch flatpak run org.gimp.Gimp ${DATA_FILES}/coffee-2mp.jpg
+        command_launch loimpress --norestore \
+            ${DATA_FILES}/example-presentation.odp
+        url_launch http://www.supercook.com/
+        url_launch https://science.nasa.gov/
+        url_launch https://www.nationalgeographic.com/
+        ;;
+    *)
+        echo >&2 "usage: $0 [light|medium|heavy]	add marginal load"
+        echo >&2 "       $0 check			check requirements for command"
+        exit 1
+        ;;
+esac


### PR DESCRIPTION
This adds a few tools for measuring aggregate system memory metrics, PSS and RSS memory usage of processes on the system (aggregated by command), and producing stress on a system in ways we might expect users to stress it.

These are designed to produce output suitable for plugging into specially-formatted spreadsheets for analysis and archiving.

NOTE: this commit adds some test files (one of which is nearly 10 MiB). It's generally not good practice to include large data files in git, so please let me know if you'd like to separate them out into a different location. I would definitely recommend against continuing to add files in this git repo and if we avoid it now we can prevent a "git clone" of this repo from always being significantly larger than it would be otherwise.