### PR TITLE
core: Include python2 and 3 pip

### DIFF
--- a/eos-core-depends
+++ b/eos-core-depends
@@ -182,7 +182,9 @@ patch
 # For modem support
 ppp
 printer-driver-all-enforce
+python-pip
 python3-flapjack
+python3-pip
 python3-showmehow
 rhythmbox (>= 2.99.1)
 rhythmbox-plugins

--- a/eos-dev-depends
+++ b/eos-dev-depends
@@ -54,7 +54,6 @@ patchutils
 pep8
 putty
 pyflakes
-python-pip
 quilt
 screen
 sl


### PR DESCRIPTION
Allow people (in particular developers) to install python modules on
unconverted systems so they can work with software that doesn't ship in
our OS.

https://phabricator.endlessm.com/T22040