### PR TITLE
core: Add GDK Pixbug thumbnailer

### DIFF
--- a/eos-core-depends
+++ b/eos-core-depends
@@ -151,6 +151,8 @@ imagemagick
 # Needed to support some Epson scanners
 imagescan
 libgphoto2-l10n
+# Needed for image thumbnailer
+libgdk-pixbuf2.0-0-bin
 # Assuming needed for iPod support
 libgpod-common
 # Assuming useful for cups


### PR DESCRIPTION
It is not included by default on libgdk-pixbuf2.0-0
anymore, and no package has a strong dependency on
it.

https://phabricator.endlessm.com/T22015