### PR TITLE
remove unoconv from the core OS

### DIFF
--- a/eos-core-depends
+++ b/eos-core-depends
@@ -195,7 +195,6 @@ tracker-miner-fs
 ttf-ancient-fonts
 ttf-femkeklaver
 yelp
-unoconv
 unrar
 # For data transfer with iOS devices
 usbmuxd


### PR DESCRIPTION
It was added for gnome-sushi which is relatively rarely used. I will
patch it to invoke unoconv via flatpak in a separate ticket.

https://phabricator.endlessm.com/T22113