### PR TITLE
T22113: tidy up spelling packages

### DIFF
--- a/eos-core-depends
+++ b/eos-core-depends
@@ -160,7 +160,6 @@ libpam-gnome-keyring
 libsasl2-modules
 modemmanager
 myspell-es
-myspell-pt
 myspell-pt-br
 myspell-th
 nautilus

--- a/eos-core-depends
+++ b/eos-core-depends
@@ -121,7 +121,10 @@ gvfs-backends
 gvfs-bin
 hunspell-ar
 hunspell-en-us
+hunspell-es
 hunspell-fr
+hunspell-pt-br
+hunspell-th
 hunspell-vi
 ibus-anthy
 ibus-avro
@@ -159,9 +162,6 @@ libpam-gnome-keyring
 # Assumed useful for apps that use libsasl2
 libsasl2-modules
 modemmanager
-myspell-es
-myspell-pt-br
-myspell-th
 nautilus
 network-manager-openvpn-gnome
 network-manager-vpnc-gnome

--- a/eos-core-depends
+++ b/eos-core-depends
@@ -4,6 +4,16 @@
 include base-depends
 include os-depends
 
+# intentionally un-sorted, to provide hunspell-dictionary early in
+# the process and avoid libenchant pulling in aspell-en and aspell
+hunspell-ar
+hunspell-en-us
+hunspell-es
+hunspell-fr
+hunspell-pt-br
+hunspell-th
+hunspell-vi
+
 alsa-utils
 apt
 apt-transport-https
@@ -119,13 +129,6 @@ gsfonts
 gtk2-engines-pixbuf
 gvfs-backends
 gvfs-bin
-hunspell-ar
-hunspell-en-us
-hunspell-es
-hunspell-fr
-hunspell-pt-br
-hunspell-th
-hunspell-vi
 ibus-anthy
 ibus-avro
 ibus-cangjie

--- a/eos-metapackage
+++ b/eos-metapackage
@@ -80,7 +80,7 @@ sub subst_depends {
 
 	# Allow the toplevel file to be missing (e.g., -recommends)
 	@deps = get_depends("$depfile") if -e "$depfile";
-	addsubstvar($package, $var, join(', ', sort @deps));
+	addsubstvar($package, $var, join(', ', @deps));
 }
 
 foreach my $package (@{$dh{DOPACKAGES}}) {


### PR DESCRIPTION
Tidying a few loose ends from https://phabricator.endlessm.com/T22113 - due to the order of apt processing eos-core dependencies, aspell-en was being installed un-necessarily, myspell is deprecated in favour of hunspell, and we started shipping myspell-pt by mistake.