### PR TITLE
Drop python2 modules

### DIFF
--- a/eos-core-depends
+++ b/eos-core-depends
@@ -175,7 +175,6 @@ patch
 # For modem support
 ppp
 printer-driver-all-enforce
-python-pip
 python3-flapjack
 python3-pip
 python3-showmehow

--- a/os-depends
+++ b/os-depends
@@ -76,7 +76,6 @@ ostree
 p7zip-full
 parted
 policykit-1
-python-gi
 python3-gi
 pulseaudio
 pulseaudio-module-bluetooth


### PR DESCRIPTION
In line with our runtimes, try to limit our python2 exposure. Ideally we'd ship python3 only in the core OS, but let's see if python2 is still dragged in as a dep after this.

https://phabricator.endlessm.com/T22180