### PR TITLE
eos-core-depends: add nautilus-extension-brasero

### DIFF
--- a/eos-core-depends
+++ b/eos-core-depends
@@ -167,6 +167,7 @@ libpam-gnome-keyring
 libsasl2-modules
 modemmanager
 nautilus
+nautilus-extension-brasero
 network-manager-openvpn-gnome
 network-manager-vpnc-gnome
 openprinting-ppds


### PR DESCRIPTION
This is recommended by brasero, and makes sense to include
as long as we have both brasero and nautilus in the core OS.

https://phabricator.endlessm.com/T21768