### PR TITLE
eos-core-depends: depend on imagescan-driver to avoid GTK2 dep

### DIFF
--- a/eos-core-depends
+++ b/eos-core-depends
@@ -147,7 +147,7 @@ iio-sensor-proxy
 # Used by cups-filters
 imagemagick
 # Needed to support some Epson scanners
-imagescan
+imagescan-driver
 libgphoto2-l10n
 # Needed for image thumbnailer
 libgdk-pixbuf2.0-bin


### PR DESCRIPTION
https://phabricator.endlessm.com/T21074