### PR TITLE
eos-core-depends: Add cracklib-runtime, needed for gnome-initial-setup

### DIFF
--- a/eos-core-depends
+++ b/eos-core-depends
@@ -30,6 +30,7 @@ chromium-browser
 coding-chatbox
 coding-game-manager
 coding-shell-extensions
+cracklib-runtime
 cups
 cups-browsed
 cups-pk-helper


### PR DESCRIPTION
This package needs to be installed in the base OSTree so that the
cracklib's password database is installed, as it's required by
the password meter widget in the "password" page of g-i-s.

https://phabricator.endlessm.com/T22217