### PR TITLE
Update eos-dev dependencies

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -167,6 +167,7 @@ Package: eos-dev
 Architecture: all
 Depends: ${misc:Depends}, ${eos:Depends}
 Recommends: ${eos:Recommends}
+Suggests: ${eos:Suggests}
 Description: EndlessOS Development Tools
  This is a collection of development tools that make development and debugging
  of EndlessOS easier and more efficient.

--- a/eos-dev-depends
+++ b/eos-dev-depends
@@ -1,66 +1,55 @@
+# The eos-dev package is intended to be installed by developers after
+# converting the system away from ostree.
+#
+# Packages listed here should be commonly used, of high value for
+# development, and expected to be relevant to a whole group of Endless
+# developers.
+#
+# If it's a tool that's only really useful to you, or you only
+# expect it to be used occasionally, then it probably doesn't belong
+# here. But do consider adding it to eos-dev-suggests so that it
+# doesn't get purged from the distro.
+
 apt-file
 apt-utils
 autoconf
 automake
 bash-completion
-bison
-bonnie++
 build-essential
 ccache
 dconf-editor
 debian-keyring
 debian-archive-keyring
 debootstrap
-devhelp
 devscripts
 diffutils
-elinks
 emacs
 endless-ca-cert
-eos-node-modules-dev
 exuberant-ctags
-flex
-fluxbox
 gdb
 gdebi
-germinate
 git
 gitk
-glade
-gnome-api-docs
 gnome-common
 gnome-devel-docs
-gparted
-gperf
 gtk-doc-tools
 htop
 iftop
 iotop
-language-pack-es
-language-pack-pt
-lftp
-libjson-glib-doc
-locate
 lsof
-ltrace
 make
-moreutils
-nethogs
-nmap
-openssh-server
+manpages
+obs-build
 osc
-p7zip-full
 patchutils
+pbuilder
 pep8
-putty
-pyflakes
+pyflakes3
 quilt
 screen
-sl
 strace
 sysstat
 tcpdump
-tig
 tmux
 util-linux
 valgrind

--- a/eos-dev-suggests
+++ b/eos-dev-suggests
@@ -1,0 +1,17 @@
+# Packages listed here become Suggested by the eos-dev package.
+#
+# Such packages aren't installed by default when you install eos-dev.
+# The main purpose of listing packages here is so that they aren't considered
+# for deletion by scripts that look for unused packages in our distro. Such
+# scripts have special provisions to consider anything listed here as a
+# required part of our distro.
+
+alsa-tools
+awscli
+codecgraph
+d-feet
+eos-dev-kernel
+evemu
+linux-tools
+pigz
+powertop

--- a/eos-metapackage
+++ b/eos-metapackage
@@ -86,6 +86,7 @@ sub subst_depends {
 foreach my $package (@{$dh{DOPACKAGES}}) {
 	subst_depends($package, "depends", "eos:Depends");
 	subst_depends($package, "recommends", "eos:Recommends");
+	subst_depends($package, "suggests", "eos:Suggests");
 }
 
 =head1 SEE ALSO


### PR DESCRIPTION
Add an explanatory comment in eos-dev-depends to explain what types of
packages should be listed there.

Remove the following packages which I assume do not meet these guidelines:
bison, bonnie++, elinks, flex, fluxbox, germinate, glade, gparted,
gperf, language-pack-*, lftp, libjson-glib-doc, locate, ltrace, moreutils,
nethogs, nmap, putty, sl, tig

gnome-api-docs is not present in the distro.

devhelp is available as a flatpak.

openssh-server and p7zip-full are included in the main distro

Switch pyflakes to python3 version

Philip C suggests that eos-node-modules-dev is probably not used
by anyone any more, since you can do node development on unconverted
systems.

Add some packages that I think should be here:
manpages, obs-build, pbuilder

Create and document a new eos-dev-suggests file, to list packages
that do not meet the eos-dev-depends guidelines, but should not be
removed from the distro as they are still valuable developer tools for
limited/occasional use.
These packages will then not be considered for deletion from our distro
if they are not needed by anything else.