### PR TITLE
flatpak-autoinstall: split to separate eos-flatpak-autoinstall package

### DIFF
--- a/eos-core-depends
+++ b/eos-core-depends
@@ -52,6 +52,7 @@ eos-companion-app-os-integration
 eos-discovery-feed
 eos-event-recorder-daemon
 eos-exploration-center
+eos-flatpak-autoinstall
 eos-gates
 eos-google-chrome-helper [amd64]
 eos-install-app-helper [amd64]


### PR DESCRIPTION
Split Flatpak auto-installation JSON files to architecture-independent
eos-flatpak-autoinstall package so they are included on ARM systems.

https://phabricator.endlessm.com/T22652