### PR TITLE
eos-uninstall-dualboot: use python3 not python (2)

### DIFF
--- a/eos-tech-support/eos-uninstall-dualboot
+++ b/eos-tech-support/eos-uninstall-dualboot
@@ -159,7 +159,7 @@ if [ "$label_type" = "dos" ]; then
     # Get the start of the first partition from sfdisk output
     # Note that sfdisk --dump lists partitions in numerical order, not on-disk order.
     # Units are sectors of 512 bytes.
-    start="$(python -c 'import re, sys; print(512 * min(map(int,
+    start="$(python3 -c 'import re, sys; print(512 * min(map(int,
         re.findall(r"start=\s*(\d+)", open(sys.argv[1]).read()))))' "$table")"
 
     boottrack_size="$(stat $boottrack_path --format=%s)"


### PR DESCRIPTION
We no longer include python 2 in the OS, but this dependency was not
declared in the package metadata.

This script is now obsolete for all but extremely old installations, but
we keep it around since it is small and referenced in our documentation
(eg https://support.endlessm.com/hc/en-us/articles/214475283).

https://phabricator.endlessm.com/T22670