### PR TITLE
Remove GTK2 modules and themes

### DIFF
--- a/base-depends
+++ b/base-depends
@@ -12,12 +12,9 @@ gstreamer1.0-plugins-good
 gstreamer1.0-plugins-ugly-lame
 gstreamer1.0-pulseaudio
 gstreamer1.0-tools
-ibus-gtk
 ibus-gtk3
-libcanberra-gtk-module
 libcanberra-gtk3-module
 libcanberra-pulse
-libcaribou-gtk-module
 libcaribou-gtk3-module
 # Mali used on arm
 libegl-mesa0 [!armhf]

--- a/eos-core-depends
+++ b/eos-core-depends
@@ -128,8 +128,6 @@ gnome-terminal
 gnome-user-guide
 gnome-user-share
 gsfonts
-# Our default GTK2 theme requires this engine.
-gtk2-engines-pixbuf
 gvfs-backends
 gvfs-bin
 ibus-anthy


### PR DESCRIPTION
Nothing in the core OS requires GTK2 anymore.

https://phabricator.endlessm.com/T21074