### PR TITLE
Depend on highcontrast-icon-theme

### DIFF
--- a/base-depends
+++ b/base-depends
@@ -6,12 +6,12 @@ eos-icon-theme
 fonts-lato
 fonts-liberation
 fonts-wqy-microhei
-gnome-themes-standard
 gstreamer1.0-libav
 gstreamer1.0-plugins-good
 gstreamer1.0-plugins-ugly-lame
 gstreamer1.0-pulseaudio
 gstreamer1.0-tools
+highcontrast-icon-theme
 ibus-gtk3
 libcanberra-gtk3-module
 libcanberra-pulse

--- a/eos-core-depends
+++ b/eos-core-depends
@@ -108,7 +108,6 @@ gdb
 gedit
 # For showing the keyboard layout from the control center
 gkbd-capplet
-gnome-accessibility-themes
 gnome-calculator
 gnome-clocks
 gnome-contacts


### PR DESCRIPTION
Instead of gnome-themes-standard, which has an unwanted dependency
on GTK2.

https://phabricator.endlessm.com/T21074