### PR TITLE
eos-download-image: attempt to handle truncated responses

### DIFF
--- a/eos-tech-support/eos-download-image
+++ b/eos-tech-support/eos-download-image
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 # vim: fileencoding=utf-8 sts=4 sw=4 et
 import argparse
+import collections
 import datetime
 import dateutil.parser
 import distutils.version
@@ -131,7 +132,7 @@ class EosDownloadImage(object):
 
         # Break the download up into ranges if it exceeds the CDN maximum
         # size.
-        ranges = []
+        ranges = collections.deque()
         start_byte = dest_size
         remaining = src_size - dest_size
         while remaining > 0:
@@ -153,7 +154,8 @@ class EosDownloadImage(object):
 
             received = dest_size
             progress(dest, int(100 * received / src_size))
-            for start, stop in ranges:
+            while ranges:
+                start, stop = ranges.popleft()
                 headers['Range'] = 'bytes={}-{}'.format(start, stop)
                 resp = self.session.get(src, headers=headers, stream=True,
                                         timeout=TIMEOUT)
@@ -163,6 +165,13 @@ class EosDownloadImage(object):
                     received += len(chunk)
                     f.write(chunk)
                     progress(dest, int(100 * received / src_size))
+
+                if received != stop + 1:
+                    ranges.appendleft((received, stop))
+
+        if received != src_size:
+            log('Received up to', received, 'but target size was', src_size)
+            exit(1)
 
     def ensure_keyring(self):
         if os.path.isfile(KEYRING_SYSTEM_PATH):

--- a/eos-tech-support/eos-download-image
+++ b/eos-tech-support/eos-download-image
@@ -96,14 +96,15 @@ class EosDownloadImage(object):
         # Check the status of an existing download
         dest_size = 0
         if os.path.exists(dest):
+            dest_stat = os.stat(dest)
+            dest_size = dest_stat.st_size
+
             if src_mtime is None:
                 # Assume it's a partial download; the signature may prove that wrong
                 outdated = False
             else:
-                dest_stat = os.stat(dest)
                 dest_mtime = datetime.datetime.fromtimestamp(dest_stat.st_mtime,
                                                              datetime.timezone.utc)
-                dest_size = dest_stat.st_size
 
                 # Is the existing file outdated? Strip off microseconds since
                 # one or the other is likely to not support it


### PR DESCRIPTION
Mazen's [seeing][1] partial downloads of images, followed by (of course) GPG verification failing. I'm not sure why; my hypothesis is that CloudFront is serving a short response because its connection to S3 drops.  This is supported by [Amazon's documentation][0]:

> **Dropped TCP Connections**
>
> If the TCP connection between CloudFront and your origin drops while your origin is returning an object to CloudFront, CloudFront behavior depends on whether your origin included a Content-Length header in the response:
>
> - Content-Length header – CloudFront returns the object to the viewer as it gets the object from your origin. However, if the value of the Content-Length header doesn't match the size of the object, CloudFront doesn't cache the object.

So add a check that each request returned the full amount of data expected; if it does not, push a new range back onto the queue. Also add a check at the very end that the full length of the file has been fetched.

I also noticed that resuming >20GB files was broken; fix this too.

[0]: https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/RequestAndResponseBehaviorCustomOrigin.html
[1]: https://phabricator.endlessm.com/P547