### PR TITLE
eos-diagnostics: Add a section for /ostree/repo/config

### DIFF
--- a/eos-tech-support/eos-diagnostics
+++ b/eos-tech-support/eos-diagnostics
@@ -543,6 +543,10 @@ let diagnostics = [
         content: function() { return trySpawn('ostree admin status'); },
     },
     {
+        title: 'OSTree repository configuration',
+        content: function() { return tryReadFile('/ostree/repo/config'); },
+    },
+    {
         title: 'Product identification',
         hardwareInfo: true,
         content: function() { return collectBoardInfo(); },


### PR DESCRIPTION
Since we seem to be getting more bug reports which concern incorrect
OSTree repository configurations, it’s probably useful to include the
contents of /ostree/repo/config in the diagnostics report.

Note that this means our repository passwords will be included in the
report, but since users can read them out of /ostree/repo/config anyway,
that’s probably not a problem.

Sample output:
  ===================================
  = OSTree repository configuration =
  ===================================
  [core]
  repo_version=1
  mode=bare
  min-free-space-percent=0
  add-remotes-config-dir=false
  …

Signed-off-by: Philip Withnall <withnall@endlessm.com>

https://phabricator.endlessm.com/T22886