### PR TITLE
eos-diagnostics: also capture OSTree config from extra SD card

### DIFF
--- a/eos-tech-support/eos-diagnostics
+++ b/eos-tech-support/eos-diagnostics
@@ -547,6 +547,11 @@ let diagnostics = [
         content: function() { return tryReadFile('/ostree/repo/config'); },
     },
     {
+        title: 'OSTree repository configuration (extra SD)',
+        content: function() { return tryReadFile('/var/endless-extra/flatpak/repo/config',
+                                                 'not a split system (or SD card missing)'); },
+    },
+    {
         title: 'Product identification',
         hardwareInfo: true,
         content: function() { return collectBoardInfo(); },


### PR DESCRIPTION
Same as cbd5f777 but additionally capture the repo config file from
the Flatpak repo on the SD card on split systems.

https://phabricator.endlessm.com/T22886