### PR TITLE
eos-write-installer: fix calculating exFAT partition start

### DIFF
--- a/eos-tech-support/eos-write-installer
+++ b/eos-tech-support/eos-write-installer
@@ -12,12 +12,12 @@ set -o pipefail
 # in physical order so Windows can mount the image
 # partition.
 
-EOS_WRITE_IMAGE=$(dirname $0)/eos-write-image
-if [ ! -f $EOS_WRITE_IMAGE ]; then
+EOS_WRITE_IMAGE=$(dirname "$0")/eos-write-image
+if [ ! -f "$EOS_WRITE_IMAGE" ]; then
     EOS_WRITE_IMAGE='eos-write-image'
 fi
-EOS_DOWNLOAD_IMAGE=$(dirname $0)/eos-download-image
-if [ ! -f $EOS_DOWNLOAD_IMAGE ]; then
+EOS_DOWNLOAD_IMAGE=$(dirname "$0")/eos-download-image
+if [ ! -f "$EOS_DOWNLOAD_IMAGE" ]; then
     EOS_DOWNLOAD_IMAGE='eos-download-image'
 fi
 
@@ -141,7 +141,7 @@ if [ ! -z "$FETCH_LATEST" ]; then
     fi
 fi
 
-if [ ! -f "$INSTALLER_IMAGE" -o ! -f "$OS_IMAGE" ]; then
+if [ ! -f "$INSTALLER_IMAGE" ] || [ ! -f "$OS_IMAGE" ]; then
     echo "Error: --installer and --os-image are both required if --latest is not specified" >&2
     echo >&2
     usage

--- a/eos-tech-support/eos-write-installer
+++ b/eos-tech-support/eos-write-installer
@@ -160,9 +160,11 @@ TABLE=$(sfdisk -d "$DEVICE")
 HEADER=$(echo "$TABLE" | grep -v '^/')
 PARTS=$(echo "$TABLE" | grep '^/' | sed -e 's/.*: //')
 
-# Grab the last sector and add one to get the start of our exfat partition
-START=$(echo "$HEADER" | grep 'last-lba' | sed -e 's/^last-lba: //')
-START=$(($START + 1))
+# Grab the start and size of the last partition; add them to get the start of
+# our exFAT partition.
+ROOT_START=$(echo "$PARTS" | sed -n -e '$ s/.*start=[ ]\+\([0-9]\+\).*$/\1/p')
+ROOT_SIZE=$(echo "$PARTS" | sed -n -e '$ s/.*size=[ ]\+\([0-9]\+\).*$/\1/p')
+START=$(( ROOT_START + ROOT_SIZE ))
 
 # Remove the last-lba line so that we fill the disk
 HEADER=$(echo "$HEADER" | sed -e '/^last-lba:/d')


### PR DESCRIPTION
Since util-linux 2.32, sfdisk detects when the secondary GPT is not at the end of the disk, and adjusts the header in the output of --dump accordingly so that if you run `sfdisk --dump $DEVICE | sfdisk $DEVICE` the GPT is extended to cover the entire device.

https://github.com/karelzak/util-linux/commit/9a8a3b88dcaec36d694aaea29d6fce5856d697c4

While this is helpful in general, it means we cannot use the last-lba header to work out where the exFAT partition should start. Instead, we can calculate it from the start and size of the final partition.

I got this wonderful regular expression from https://github.com/endlessm/eos-boot-helper/blob/a4dee04/dracut/repartition/endless-repartition.sh#L163

While I was here I fixed some shellcheck warnings.

https://phabricator.endlessm.com/T22943