### PR TITLE
eos-core-depends: add libblockdev-crypto2

### DIFF
--- a/eos-core-depends
+++ b/eos-core-depends
@@ -147,6 +147,7 @@ iio-sensor-proxy
 imagemagick
 # Needed to support some Epson scanners
 imagescan-driver
+libblockdev-crypto2
 libgphoto2-l10n
 # Needed for image thumbnailer
 libgdk-pixbuf2.0-bin


### PR DESCRIPTION
Required to enable reading encrypted USB devices.

https://phabricator.endlessm.com/T23046