### PR TITLE
Remove coding dependencies from OSTree

### DIFF
--- a/eos-core-depends
+++ b/eos-core-depends
@@ -27,8 +27,6 @@ brasero-cdrkit
 cdrdao
 cheese
 chromium-browser
-coding-chatbox
-coding-game-manager
 coding-shell-extensions
 cracklib-runtime
 cups
@@ -179,12 +177,10 @@ ppp
 printer-driver-all-enforce
 python3-flapjack
 python3-pip
-python3-showmehow
 rhythmbox (>= 2.99.1)
 rhythmbox-plugins
 rtkit
 shotwell
-showmehow-service
 simple-scan
 smbclient
 strace


### PR DESCRIPTION
We have those available as flatpaks now. These can be removed.
I kept coding-shell-extensions, as that's independent, but we will
have to understand what to do there too.

https://phabricator.endlessm.com/T23278