### PR TITLE
os-depends: Drop leftover reference to linux-image-generic-64

### DIFF
--- a/os-depends
+++ b/os-depends
@@ -56,10 +56,9 @@ libpam-systemd
 linux-firmware
 # Kernel package. All arm installs use platform specific kernels, so
 # those appear in the platform specific -depends files. For amd64,
-# prefer the linux-signed-image variant, which contains the kernel
-# signed for UEFI. The -64 variant is a 64 bit kernel that we install on
-# i386.
-linux-signed-image-generic [amd64] | linux-image-generic-64 [i386]
+# use the linux-signed-image variant, which contains the kernel
+# signed for UEFI.
+linux-signed-image-generic [amd64]
 lsb-base
 lsb-release
 mobile-broadband-provider-info


### PR DESCRIPTION
We dropped support for the i686 architecture on EOS 3.0 and don't build
linux-image-generic-64 since then.

https://phabricator.endlessm.com/T23361