### PR TITLE
eos-core: add u2f-hidraw-policy

### DIFF
--- a/eos-core-depends
+++ b/eos-core-depends
@@ -194,6 +194,7 @@ tracker-miner-fs
 ttf-ancient-fonts
 ttf-femkeklaver
 yelp
+u2f-hidraw-policy
 unrar
 # For data transfer with iOS devices
 usbmuxd

--- a/eos-core-depends
+++ b/eos-core-depends
@@ -37,9 +37,9 @@ debconf-i18n
 dnsmasq-base
 # For brasero video DVD functionality
 dvdauthor
-eog
 # For flatpak-builder
 elfutils
+eog
 eos-acknowledgements
 eos-adblock-plus-extensions
 eos-b43fw-install
@@ -64,11 +64,11 @@ eos-speedwagon
 eos-updater-tools
 evince
 evolution
-evolution-plugins
 # For spam filtering
 evolution-plugin-bogofilter
 # For Outlook import
 evolution-plugin-pstimport
+evolution-plugins
 file-roller
 flatpak
 flatpak-builder
@@ -84,10 +84,10 @@ fonts-indic
 fonts-kacst
 fonts-khmeros
 fonts-knda
+fonts-linuxlibertine
 fonts-nanum
 fonts-nanum-coding
 fonts-noto-mono
-fonts-linuxlibertine
 fonts-ocr-a
 fonts-paktype
 fonts-sarai
@@ -146,9 +146,9 @@ imagemagick
 # Needed to support some Epson scanners
 imagescan-driver
 libblockdev-crypto2
-libgphoto2-l10n
 # Needed for image thumbnailer
 libgdk-pixbuf2.0-bin
+libgphoto2-l10n
 # Assuming needed for iPod support
 libgpod-common
 # Assuming useful for cups
@@ -193,7 +193,6 @@ tracker
 tracker-miner-fs
 ttf-ancient-fonts
 ttf-femkeklaver
-yelp
 u2f-hidraw-policy
 unrar
 # For data transfer with iOS devices
@@ -206,5 +205,6 @@ xapian-bridge
 xbrlapi
 xdg-desktop-portal
 xdg-desktop-portal-gtk
+yelp
 # Used by mutter for showing dialogs
 zenity


### PR DESCRIPTION
This sets permissions on USB U2F tokens so they can be used by unprivileged processes.

I also alphabetized the few unalphabetized entries in this file, as a later patch in case we want to cherry-pick the functional change back to eos3.4.

https://phabricator.endlessm.com/T23496