### PR TITLE
eos-core: add libu2f-udev

### DIFF
--- a/eos-core-depends
+++ b/eos-core-depends
@@ -37,9 +37,9 @@ debconf-i18n
 dnsmasq-base
 # For brasero video DVD functionality
 dvdauthor
-eog
 # For flatpak-builder
 elfutils
+eog
 eos-acknowledgements
 eos-adblock-plus-extensions
 eos-b43fw-install
@@ -64,11 +64,11 @@ eos-speedwagon
 eos-updater-tools
 evince
 evolution
-evolution-plugins
 # For spam filtering
 evolution-plugin-bogofilter
 # For Outlook import
 evolution-plugin-pstimport
+evolution-plugins
 file-roller
 flatpak
 flatpak-builder
@@ -84,10 +84,10 @@ fonts-indic
 fonts-kacst
 fonts-khmeros
 fonts-knda
+fonts-linuxlibertine
 fonts-nanum
 fonts-nanum-coding
 fonts-noto-mono
-fonts-linuxlibertine
 fonts-ocr-a
 fonts-paktype
 fonts-sarai
@@ -146,9 +146,9 @@ imagemagick
 # Needed to support some Epson scanners
 imagescan-driver
 libblockdev-crypto2
-libgphoto2-l10n
 # Needed for image thumbnailer
 libgdk-pixbuf2.0-bin
+libgphoto2-l10n
 # Assuming needed for iPod support
 libgpod-common
 # Assuming useful for cups
@@ -194,7 +194,6 @@ tracker
 tracker-miner-fs
 ttf-ancient-fonts
 ttf-femkeklaver
-yelp
 unrar
 # For data transfer with iOS devices
 usbmuxd
@@ -206,5 +205,6 @@ xapian-bridge
 xbrlapi
 xdg-desktop-portal
 xdg-desktop-portal-gtk
+yelp
 # Used by mutter for showing dialogs
 zenity

--- a/eos-core-depends
+++ b/eos-core-depends
@@ -163,6 +163,7 @@ libnss-systemd
 libpam-gnome-keyring
 # Assumed useful for apps that use libsasl2
 libsasl2-modules
+libu2f-udev
 modemmanager
 nautilus
 nautilus-extension-brasero


### PR DESCRIPTION
This sets permissions on USB U2F tokens so they can be used by unprivileged processes.

I also alphabetized the few unalphabetized entries in this file, as a later patch in case we want to cherry-pick the functional change back to eos3.4.

This is the approach taken by Debian and its descendents. (https://github.com/endlessm/eos-meta/pull/527 is an alternative approach, following Fedora's approach.)

https://phabricator.endlessm.com/T23496