### PR TITLE
eos-tech-support: collect `ostree refs`

### DIFF
--- a/eos-tech-support/eos-diagnostics
+++ b/eos-tech-support/eos-diagnostics
@@ -543,6 +543,15 @@ let diagnostics = [
         content: function() { return trySpawn('ostree admin status'); },
     },
     {
+        title: 'OSTree refs',
+        content: function() {
+            let output = trySpawn('ostree refs');
+            let refs = output.split('\n');
+            refs.sort();
+            return refs.join('\n');
+        },
+    },
+    {
         title: 'OSTree repository configuration',
         content: function() { return tryReadFile('/ostree/repo/config'); },
     },


### PR DESCRIPTION
While this largely duplicates the two `flatpak list` incantations, it
would have allowed us to notice sooner that the local:factory and
eos:eos2/i386 refs were still around on a system upgraded from eos2. We
could try to filter out known flatpak remotes from this list but it
doesn't seem worth it. OTOH it *does* seem worth sorting the list
because it's otherwise illegible.

https://phabricator.endlessm.com/T23443