### PR TITLE
os-depends: include GPG dirmngr

### DIFF
--- a/os-depends
+++ b/os-depends
@@ -6,6 +6,7 @@ cryptsetup
 dbus-user-session
 dbus-x11
 dconf-cli
+dirmngr
 dosfstools
 dracut
 eject


### PR DESCRIPTION
Since GPG v2, network code for key retrieval has been moved into this separate
process/package. Include it in the OS so that scripts interacting with gpg
keyservers work correctly, such as the hplip plugin installer.

https://phabricator.endlessm.com/T23558