### PR TITLE
eos-diagnostics: Ignore failure to get the renderer without D-Bus

### DIFF
--- a/eos-tech-support/eos-diagnostics
+++ b/eos-tech-support/eos-diagnostics
@@ -13,10 +13,14 @@ function collectGraphicsRenderer() {
         '</interface>' +
         '</node>';
 
-    let sessionProxyProto = Gio.DBusProxy.makeProxyWrapper(iface);
-    let sessionProxy = new sessionProxyProto(Gio.DBus.session,
+    let sessionProxy = null;
+    try {
+        let sessionProxyProto = Gio.DBusProxy.makeProxyWrapper(iface);
+        sessionProxy = new sessionProxyProto(Gio.DBus.session,
                                              'org.gnome.SessionManager',
                                              '/org/gnome/SessionManager');
+    } catch (e) {
+    }
 
     let output = 'Renderer: ';
     if (sessionProxy)


### PR DESCRIPTION
If eos-diagnostics is being called from outside a user session, there
will be no session bus and no $DISPLAY variable to auto-start one with,
so creating a proxy for the SessionManager will fail.

Catch and ignore that failure.

This is triggered when calling eos-diagnostics on OpenQA VMs.

Signed-off-by: Philip Withnall <withnall@endlessm.com>