### PR TITLE
eos-dev-suggests: add gcovr

### DIFF
--- a/eos-dev-depends
+++ b/eos-dev-depends
@@ -18,8 +18,8 @@ bash-completion
 build-essential
 ccache
 dconf-editor
-debian-keyring
 debian-archive-keyring
+debian-keyring
 debootstrap
 devscripts
 diffutils

--- a/eos-dev-suggests
+++ b/eos-dev-suggests
@@ -16,6 +16,7 @@ codecgraph
 d-feet
 eos-dev-kernel
 evemu-tools
+gcovr
 gnome-tweak-tool
 gparted
 jq

--- a/eos-dev-suggests
+++ b/eos-dev-suggests
@@ -6,10 +6,10 @@
 # scripts have special provisions to consider anything listed here as a
 # required part of our distro.
 
-arcanist
 ack-grep
 alsa-tools
 ansible
+arcanist
 at
 awscli
 codecgraph
@@ -26,9 +26,9 @@ multistrap
 nmap
 pesign
 pigz
+powertop
 python3-boto
 python3-boto3
-powertop
 qemu-utils
 resolvconf
 shim


### PR DESCRIPTION
The Meson build system uses this, if available, to generate
Cobertura-compatible XML code coverage reports. It's installed in the
buildroot while building packages on Jenkins before submitting them to OBS.

https://phabricator.endlessm.com/T23921