### PR TITLE
eos-core-depends: remove coding-shell-extensions package

### DIFF
--- a/eos-core-depends
+++ b/eos-core-depends
@@ -27,7 +27,6 @@ brasero-cdrkit
 cdrdao
 cheese
 chromium-browser
-coding-shell-extensions
 cracklib-runtime
 cups
 cups-browsed


### PR DESCRIPTION
This is not used by Endless Hack.