### PR TITLE
eos-diagnostics: Trim '\0' from DT compatible string

### DIFF
--- a/eos-tech-support/eos-diagnostics
+++ b/eos-tech-support/eos-diagnostics
@@ -53,6 +53,7 @@ function collectBoardInfo() {
     try {
         let [res, contents] = GLib.file_get_contents('/proc/device-tree/compatible');
         output += 'compatible: ' + contents;
+        output = output.replace(/\0/g, ' ');
     } catch (e) { }
 
     return output;


### PR DESCRIPTION
https://phabricator.endlessm.com/T23912