### PR TITLE
os-depends: depend on eos-payg-nonfree

### DIFF
--- a/os-depends
+++ b/os-depends
@@ -18,6 +18,7 @@ eos-default-settings
 eos-factory-tools
 eos-keyring
 eos-license-service
+eos-payg-nonfree
 eos-plymouth-theme
 eos-tech-support
 eos-updater


### PR DESCRIPTION
Previously, eos-paygd was pulled in as a dependency of gnome-shell; now,
we'll pull it in as a dependency of this as well.

https://phabricator.endlessm.com/T23606