### PR TITLE
eos-tech-support: add script to reset Clubhouse quests

### DIFF
--- a/eos-tech-support/eos-hack-reset-clubhouse
+++ b/eos-tech-support/eos-hack-reset-clubhouse
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+echo "Killing com.endlessm.Clubhouse"
+gdbus call --session \
+    --dest com.endlessm.Clubhouse \
+    --object-path /com/endlessm/Clubhouse \
+    --method org.gtk.Actions.Activate quit [] []
+
+echo "Resetting game state"
+gdbus call --session \
+    --dest com.endlessm.GameStateService \
+    --object-path /com/endlessm/GameStateService \
+    --method com.endlessm.GameStateService.Reset
+
+echo "Resetting desktop icons"
+eos-reset-desktop
+
+echo "Done"


### PR DESCRIPTION
Here is the reset script, now with the logic moved to `hack-game-state-service`.

https://phabricator.endlessm.com/T24374