### PR TITLE
os-depends: ship xserver-xorg-input-wacom

### DIFF
--- a/os-depends
+++ b/os-depends
@@ -96,6 +96,7 @@ xauth
 xdg-user-dirs
 xdg-user-dirs-gtk
 xserver-xorg-input-libinput
+xserver-xorg-input-wacom
 # Some of these are really specific to x86, but just keep them off of arm for now
 xserver-xorg-video-amdgpu [!armhf]
 xserver-xorg-video-fbdev [!armhf]


### PR DESCRIPTION
It's a small package and all that's needed to enable the GNOME Wacom
integration. Let's ship it in the core OS.

https://phabricator.endlessm.com/T14678