### PR TITLE
tech-support/eos-convert-system*: fix journal dir perms

### DIFF
--- a/eos-tech-support/eos-convert-system
+++ b/eos-tech-support/eos-convert-system
@@ -124,6 +124,7 @@ eos-convert-passwd --root=/sysroot
 
 # Make the systemd journal persistent
 mkdir -p /var/log/journal
+systemd-tmpfiles --create --prefix /var/log/journal
 
 # Enable systemd coredumps storage
 eos-enable-coredumps /sysroot/etc

--- a/eos-tech-support/eos-convert-system-qa
+++ b/eos-tech-support/eos-convert-system-qa
@@ -65,6 +65,7 @@ fi
 if $JOURNAL; then
     echo "Configuring systemd journal to be persistent."
     mkdir /var/log/journal
+    systemd-tmpfiles --create --prefix /var/log/journal
 fi
 
 # Enable systemd coredumps storage


### PR DESCRIPTION
The eos-convert-system{,-qa} scripts have the same bug as described/seen in
https://phabricator.endlessm.com/T22687 which is that the journal dir
permissions are not correctly set after it is created, meaning that depending
on the execution environment of the script / setting of umask, some users (even
administrators) may be left unable to read the journal folder.