### PR TITLE
eos-stage-flatpak: cope with remote names containing '.'

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -199,7 +199,10 @@ Description: EndlessOS Kernel Team Development Tools
 
 Package: eos-tech-support
 Architecture: all
-Depends: ${misc:Depends}, ${eos:Depends}, usbutils
+Depends: ${eos:Depends},
+         ${misc:Depends},
+         ostree (>= 2018.8),
+         usbutils,
 Description: EndlessOS Technical Support Tools
  This is a collection of technical support tools that are installed by default
  with the EndlessOS operating system.  They are not required as part of the

--- a/eos-tech-support/eos-stage-flatpak
+++ b/eos-tech-support/eos-stage-flatpak
@@ -58,7 +58,7 @@ else
 fi
 
 for remote in `flatpak remote-list --system | awk {'print $1'}` ; do
-    url=$(ostree --repo="$flatpak_repo" config get 'remote "'"$remote"'".url')
+    url=$(ostree --repo="$flatpak_repo" config get --group 'remote "'"$remote"'"' 'url')
     if [[ "$url" == *"ostree.endlessm.com"* ]] ; then
         repo=${url##*/}
         new_url="${base_url}/${repo}"
@@ -70,7 +70,7 @@ for remote in `flatpak remote-list --system | awk {'print $1'}` ; do
         flatpak remote-modify "$remote" --url="$new_url"
 
         # Update the collection ID if it's set
-        collection_id=$(ostree --repo="$flatpak_repo" config get 'remote "'"$remote"'".collection-id' 2>/dev/null || echo "")
+        collection_id=$(ostree --repo="$flatpak_repo" config get --group 'remote "'"$remote"'"' 'collection-id' 2>/dev/null || echo "")
         if [ -n "$collection_id" ] ; then
             # For info on the collection ID patterns, see
             # https://phabricator.endlessm.com/w/software/ostree/infrastructure/#repository-stages


### PR DESCRIPTION
`flatpak-builder --install`, among other tools, creates remotes of the
form "org.vim.Vim-origin". `ostree config get KEY` splits KEY on the
first '.' it contains, leading to:

    ++ ostree --repo=/var/lib/flatpak/repo config get 'remote "org.vim.Vim-origin".url'
    error: Key file does not have group “remote "org”

Since v2018.8, `ostree config get|set` accept a `--group` parameter,
precisely to deal with this case. Bump the version we depend on, and use
it.

https://phabricator.endlessm.com/T25253