### PR TITLE
base-depends: lame plugin moved to gstreamer-plugins-good

### DIFF
--- a/base-depends
+++ b/base-depends
@@ -8,7 +8,6 @@ fonts-liberation
 fonts-wqy-microhei
 gstreamer1.0-libav
 gstreamer1.0-plugins-good
-gstreamer1.0-plugins-ugly-lame
 gstreamer1.0-pulseaudio
 gstreamer1.0-tools
 gstreamer1.0-vaapi


### PR DESCRIPTION
The lame plugin that we carefully shipped in its own package is
now present in the regular gstreamer-plugins-good packages.
Remove this package that is being dropped from the distro.

https://phabricator.endlessm.com/T25185