### PR TITLE
base-depends: Add xz-utils to ensure xz available

### DIFF
--- a/base-depends
+++ b/base-depends
@@ -36,3 +36,4 @@ netbase
 sound-theme-freedesktop
 ttf-freefont
 xdg-utils
+xz-utils


### PR DESCRIPTION
Recently debian dropped the xz-utils priority from required to
standard[1], which means its no longer included by apt-bootstrap in the
OS. Although it's not required for the OS to operate, the ostree build
is currently breaking trying to create a xz compressed tarball. That
seems pretty useful generally, so make sure xz is included in the OS.

1. https://repo.or.cz/xz/debian.git/commit/3ed34568d0b311a6998a1aa8f6352b13849483ed

https://phabricator.endlessm.com/T25399