### PR TITLE
Check that deps exist at build time

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ debian/eos-core
 debian/eos-dev
 debian/eos-dev-kernel
 debian/eos-dev-kernel-amd64
+obj-*

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,9 @@
 *.swp
 *~
 debian/*substvars
+debian/.debhelper
 debian/eos-apps
 debian/eos-core
 debian/eos-dev
+debian/eos-dev-kernel
+debian/eos-dev-kernel-amd64

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 *.log
-debian/*substvars
-debian/eos-core
-debian/eos-apps
-debian/eos-dev
 *.swp
 *~
+debian/*substvars
+debian/eos-apps
+debian/eos-core
+debian/eos-dev

--- a/debian/control
+++ b/debian/control
@@ -4,7 +4,9 @@ Priority: optional
 Maintainer: EndlessM Maintainers <maintainers@endlessm.com>
 Uploaders: Sjoerd Simons <sjoerd.simons@collabora.co.uk>, Hector Oron <hector.oron@collabora.co.uk>, Srdjan Grubor <sgnn7@sgnn7.org>
 Standards-Version: 3.9.3
-Build-Depends: debhelper (>= 9)
+Build-Depends: debhelper (>= 9),
+               libdpkg-perl,
+               meson,
 Homepage: http://www.endlessm.com
 
 Package: eos-core

--- a/debian/eos-tech-support.install
+++ b/debian/eos-tech-support.install
@@ -1,1 +1,1 @@
-eos-tech-support/* usr/bin
+eos-tech-support/eos-* usr/bin

--- a/debian/eos-tech-support.postinst
+++ b/debian/eos-tech-support.postinst
@@ -1,4 +1,5 @@
 #!/bin/sh
+set -e
 
 # On upgrades of converted systems, try to merge the passwd and group
 # files in /lib back to /etc. If we're on ostree system (ostree= in

--- a/debian/rules
+++ b/debian/rules
@@ -7,6 +7,9 @@
 %:
 	dh $@
 
+override_dh_auto_configure:
+	dh_auto_configure -- -Dcheck-deps=false
+
 override_dh_installdeb:
 	./eos-metapackage
 	dh_installdeb

--- a/eos-dev-depends
+++ b/eos-dev-depends
@@ -51,7 +51,7 @@ strace
 sysstat
 tcpdump
 tmux
-util-linux
+util-linux (>= 2.32)
 valgrind
 vim
 x11-utils

--- a/eos-dev-kernel-depends
+++ b/eos-dev-kernel-depends
@@ -18,7 +18,7 @@ make
 patchutils
 strace
 tig
-util-linux
+util-linux (>= 2.32)
 valgrind
 vim
 zsh

--- a/eos-dev-recommends
+++ b/eos-dev-recommends
@@ -1,2 +1,1 @@
-eos-dev-config
 synergy

--- a/eos-metapackage
+++ b/eos-metapackage
@@ -10,10 +10,13 @@ eos-metapackage - create metapackages from depends files
 use strict;
 
 use Debian::Debhelper::Dh_Lib;
+use Dpkg::Deps qw( deps_parse deps_iterate );
 
 =head1 SYNOPSIS
 
 B<eos-metapackage> [S<B<debhelper options>>]
+
+B<eos-metapackage --check-params>
 
 =head1 DESCRIPTION
 
@@ -30,6 +33,10 @@ The format of the dependency files is one package per line. Lines
 beginning with "#" are skipped. Lines beginning with "include" will read
 in the referenced file.
 
+If run with C<--check-params>, rather than populating substvar files, the
+program will check whether all external packages for the current
+architecture listed in dependency files are installable.
+
 =head1 EXAMPLES
 
 eos-metapackage must be called before C<dh_installdeb>.
@@ -40,7 +47,10 @@ eos-metapackage must be called before C<dh_installdeb>.
 
 =cut
 
-init();
+my $CheckDeps = 0;
+init(options => {
+	"check-deps" => \$CheckDeps,
+});
 
 sub get_depends {
 	my $name=shift;
@@ -71,16 +81,52 @@ sub get_depends {
 	return @deps;
 }
 
+sub check_installable {
+	my ($depfile, $deps) = @_;
+	my @cmd;
+	my %options = (
+		# ignore packages for foreign architectures; they may not be
+		# installable on this architecture, and that's OK.
+		reduce_restrictions => 1,
+	);
+
+	verbose_print("checking all packages in $depfile are installable");
+	deps_iterate(deps_parse($deps, %options), sub {
+		my ($d) = @_;
+		my $package = $d->{package};
+
+		if (grep { $package eq $_ } @{$dh{DOPACKAGES}}) {
+			verbose_print("skipping '$package' which comes from this project");
+		} else {
+			push @cmd, $package;
+		}
+
+		return 1; # keep iteratin'
+	});
+
+	if (@cmd > 0) {
+		unshift(@cmd, ("apt-get", "install", "--download-only", "--dry-run", "--quiet"));
+		doit(@cmd);
+	}
+}
+
 sub subst_depends {
 	my $package=shift;
 	my $type=shift;
 	my $var=shift;
 	my $depfile="$package-$type";
 	my @deps;
+	my $deps;
 
 	# Allow the toplevel file to be missing (e.g., -recommends)
 	@deps = get_depends("$depfile") if -e "$depfile";
-	addsubstvar($package, $var, join(', ', @deps));
+	$deps = join(', ', @deps);
+
+	if ($CheckDeps) {
+		check_installable($depfile, $deps);
+	} else {
+		addsubstvar($package, $var, $deps);
+	}
 }
 
 foreach my $package (@{$dh{DOPACKAGES}}) {

--- a/eos-tech-support-depends
+++ b/eos-tech-support-depends
@@ -1,9 +1,11 @@
 bash-completion
 eos-image-keyring
 file
+gjs
 iw
 lshw
 pv
+python3
 python3-dateutil
 python3-requests
 screen

--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,14 @@
+project('eos-meta')
+
+if get_option('check-deps')
+  test('check-deps',
+    find_program('eos-metapackage'),
+    workdir : meson.current_source_dir(),
+    args : [
+      '--check-deps',
+    ],
+    env : [
+      'DH_VERBOSE=1',
+    ],
+  )
+endif

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,0 +1,5 @@
+option('check-deps',
+  type : 'boolean',
+  value : true,
+  description : 'Checks that all listed external packages are installable',
+)


### PR DESCRIPTION
This would have prevented me from merging https://github.com/endlessm/eos-meta/pull/554 when fuse-overlayfs was not in the distro.

There are also some other fixes in here for things that lintian complained about. Many of them were harmless but one was real.

https://phabricator.endlessm.com/T26007