### PR TITLE
Remove eos-companion-app-os-integration

### DIFF
--- a/eos-core-depends
+++ b/eos-core-depends
@@ -45,7 +45,6 @@ eos-b43fw-install
 eos-browser-tools
 eos-chrome-plugin-updater
 eos-codecs-manager
-eos-companion-app-os-integration
 eos-discovery-feed
 eos-event-recorder-daemon
 eos-exploration-center


### PR DESCRIPTION
The companion app itself is currently not available for download, and
we don't currently have the resources to resurrect it and investigate
issues that were reported before it was pulled from Google Play. (I have
the app installed on my tablet; while it can see my Endless computers on
the network, it fails to actually load any content from either of them.)

For the time being, remove the integration from the OS.

https://phabricator.endlessm.com/T25970