### PR TITLE
eos-write-live-image: support windows tool for writable images

### DIFF
--- a/eos-tech-support/eos-write-live-image
+++ b/eos-tech-support/eos-write-live-image
@@ -44,6 +44,7 @@ EXPAND=
 SIZE=
 WRITABLE=
 BIOS=true
+WINDOWS_TOOL_PROVIDED=
 FORCE=
 PERSONALITY=base
 PRODUCT=eos
@@ -127,6 +128,7 @@ while true; do
         -x|--windows-tool)
             shift
             WINDOWS_TOOL="$1"
+            WINDOWS_TOOL_PROVIDED=true
             shift
             ;;
         -l|--latest)
@@ -432,6 +434,9 @@ if [ ! "$WRITABLE" ]; then
     cp "${BOOT_ZIP}" "${BOOT_ZIP}.asc" "${EXTRACTED_SIGNATURE}" \
         "$DIR_IMAGES_ENDLESS/"
     echo "$OS_IMAGE_UNCOMPRESSED_BASENAME" > "${DIR_IMAGES_ENDLESS}/live"
+fi
+
+if [ ! "$WRITABLE" ] || [ "$WINDOWS_TOOL_PROVIDED" ]; then
     cp "$WINDOWS_TOOL" "$DIR_IMAGES/"
     WINDOWS_TOOL_BASENAME="$(basename "$WINDOWS_TOOL")"
     sed 's/$/\r/' <<AUTORUN_INF | iconv -f utf-8 -t utf-16 > "${DIR_IMAGES}/autorun.inf"


### PR DESCRIPTION
Previously eos-write-live-image only wrote the windows tool to the
removable drive if a non-writable live was requested.

This commit changes the behavior so that if a windows tool was
explicitly provided to the script, it will be written regardless
of whether the image was writable or not, and preserves the existing
behavior otherwise.

https://phabricator.endlessm.com/T26120