### PR TITLE
Add mousetweaks to eos-core-depends

### DIFF
--- a/eos-core-depends
+++ b/eos-core-depends
@@ -165,6 +165,8 @@ libpam-gnome-keyring
 # Assumed useful for apps that use libsasl2
 libsasl2-modules
 modemmanager
+# For mouse accessibility options in gnome-settings-daemon
+mousetweaks
 nautilus
 nautilus-extension-brasero
 network-manager-openvpn-gnome


### PR DESCRIPTION
It is recommended by gnome-settings-daemon and, because
we do not install recommended packaged by default, it
needs to be explicitly included.

https://phabricator.endlessm.com/T26202