### PR TITLE
Remove eos-composite-mode

### DIFF
--- a/os-depends
+++ b/os-depends
@@ -12,7 +12,6 @@ dracut
 eject
 efibootmgr [amd64]
 eos-boot-helper
-eos-composite-mode
 eos-default-background
 eos-default-settings
 eos-factory-tools


### PR DESCRIPTION
We are dropping composite mode support. The CVBS connector is already
disabled on Endless Mini since 3.5.8.

https://phabricator.endlessm.com/T25621