### PR TITLE
eos-toolbox-dev: Remove buildah

### DIFF
--- a/eos-core-depends
+++ b/eos-core-depends
@@ -24,7 +24,6 @@ avahi-utils
 bluez-obexd
 brasero
 brasero-cdrkit
-buildah
 cdrdao
 cheese
 chromium-browser

--- a/eos-dev-suggests
+++ b/eos-dev-suggests
@@ -9,7 +9,6 @@
 # Robert McQueen is prototyping these container-based development tools.
 # They will probably be added to the ostree once ready.
 toolbox
-buildah
 
 # Robert McQueen is prototyping this for encrypted home directories.
 # It will probably be added to the ostree once ready.

--- a/eos-toolbox-dev-depends
+++ b/eos-toolbox-dev-depends
@@ -17,7 +17,6 @@ apt-utils
 autoconf
 automake
 bash-completion
-buildah
 build-essential
 ca-certificates
 ccache


### PR DESCRIPTION
buildah was getting installed as a dep for the eos-toolbox-dev
metapackage in order to allow running toolbox inside eos-toolbox
containers.
Now that toolbox (0.0.10) doesn't depend on buildah anymore, lets
remove the dep as not needed anymore.

https://phabricator.endlessm.com/T26430

Signed-off-by: Andre Moreira Magalhaes <andre@endlessm.com>