### PR TITLE
eos-{core,toolbox-dev}-depends: add podman-docker

### DIFF
--- a/eos-core-depends
+++ b/eos-core-depends
@@ -183,6 +183,7 @@ openssh-server
 # For flatpak-builder
 patch
 podman
+podman-docker
 # For modem support
 ppp
 printer-driver-all-enforce

--- a/eos-toolbox-dev-depends
+++ b/eos-toolbox-dev-depends
@@ -53,6 +53,7 @@ patchutils
 pbuilder
 pycodestyle
 podman
+podman-docker
 procps
 python3
 quilt


### PR DESCRIPTION
On balance, even if not 100% compatible, providing docker with podman improves
discoverability of the OS feature.