### PR TITLE
Remove old ARM platforms

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -45,28 +45,6 @@ Description: Target packages of the Endless distribution for amd64
  .
  This set provides the platform specific package list for amd64.
 
-Package: eos-core-odroidu2
-Architecture: armhf
-Depends: ${misc:Depends}, ${eos:Depends}
-Description: Target packages of the Endless distribution for odroidu2
- This package depends on all packages required for the Endless OS core images
- .
- It is also used to help ensure proper upgrades, so it is recommended that
- it not be removed.
- .
- This set provides the platform specific package list for armhf-odroidu2.
-
-Package: eos-core-sqwerty
-Architecture: armhf
-Depends: ${misc:Depends}, ${eos:Depends}
-Description: Target packages of the Endless distribution for sqwerty
- This package depends on all packages required for the Endless OS core images
- .
- It is also used to help ensure proper upgrades, so it is recommended that
- it not be removed.
- .
- This set provides the platform specific package list for armhf-sqwerty.
-
 Package: eos-core-ec100
 Architecture: armhf
 Depends: ${misc:Depends}, ${eos:Depends}
@@ -88,17 +66,6 @@ Description: Target packages of the Endless distribution for S905X-based boards
  it not be removed.
  .
  This set provides the platform specific package list for armhf-s905x
-
-Package: eos-core-rk3288
-Architecture: armhf
-Depends: ${misc:Depends}, ${eos:Depends}
-Description: Target packages of the Endless distribution for rk3288-based boards
- This package depends on all packages required for the Endless OS core images
- .
- It is also used to help ensure proper upgrades, so it is recommended that
- it not be removed.
- .
- This set provides the platform specific package list for armhf-rk3288
 
 Package: eos-core-nexthw
 Architecture: amd64

--- a/eos-core-odroidu2-depends
+++ b/eos-core-odroidu2-depends
@@ -1,3 +1,0 @@
-include odroidu2-depends
-include os-odroidu2-depends
-eos-core

--- a/eos-core-rk3288-depends
+++ b/eos-core-rk3288-depends
@@ -1,3 +1,0 @@
-include os-rk3288-depends
-include rk3288-depends
-eos-core

--- a/eos-core-sqwerty-depends
+++ b/eos-core-sqwerty-depends
@@ -1,3 +1,0 @@
-include os-sqwerty-depends
-include sqwerty-depends
-eos-core

--- a/odroidu2-depends
+++ b/odroidu2-depends
@@ -1,4 +1,0 @@
-# odroidu2 hardware specific packages
-mali400-drivers-exynos4
-linux-image-3.17-trunk-armmp
-u-boot-exynos4-odroid

--- a/os-odroidu2-depends
+++ b/os-odroidu2-depends
@@ -1,2 +1,0 @@
-xserver-xorg
-xserver-xorg-video-armsoc

--- a/os-rk3288-depends
+++ b/os-rk3288-depends
@@ -1,2 +1,0 @@
-mali-t76x-drivers-rk3288
-xserver-xorg-rockchip

--- a/os-sqwerty-depends
+++ b/os-sqwerty-depends
@@ -1,1 +1,0 @@
-xserver-xorg

--- a/rk3288-depends
+++ b/rk3288-depends
@@ -1,6 +1,0 @@
-# rockchip/rk3288 hardware specific packages
-linux-image-4.4.0-1-rockchip
-u-boot-rockchip-jerry
-cgpt
-flashrom
-ectool

--- a/sqwerty-depends
+++ b/sqwerty-depends
@@ -1,6 +1,0 @@
-# sqwerty hardware specific packages
-libegl1-mali400
-libgles2-mali400
-linux-image-3.17-trunk-armmp
-mali400-corelibs
-u-boot-exynos4-odroid


### PR DESCRIPTION
sqwerty was a Samsung-based device that never went beyond prototype.
odroidu2 was the prototype that predated that.
We haven't worked with these platforms in years.

RK3288 has been discontinued for EOS-3.7.0.

https://phabricator.endlessm.com/T26837