### PR TITLE
Revert "Add mousetweaks to eos-core-depends"

### DIFF
--- a/eos-core-depends
+++ b/eos-core-depends
@@ -172,8 +172,6 @@ libpam-gnome-keyring
 # Assumed useful for apps that use libsasl2
 libsasl2-modules
 modemmanager
-# For mouse accessibility options in gnome-settings-daemon
-mousetweaks
 nautilus
 nautilus-extension-brasero
 network-manager-openvpn-gnome


### PR DESCRIPTION
This reverts commit 071a7844ab9305dd36b1a9764f6191dc744445f0. Per https://phabricator.endlessm.com/T26202#728635, mousetweaks is no longer used in GNOME 3.34: the functionality is built in.

https://phabricator.endlessm.com/T26202