### PR TITLE
eos-core-depends: add recommends for speech-dispatcher

### DIFF
--- a/eos-core-depends
+++ b/eos-core-depends
@@ -191,6 +191,8 @@ simple-scan
 # For rootless podman
 slirp4netns
 smbclient
+sound-icons
+speech-dispatcher-espeak-ng
 strace
 system-config-printer-gnome
 system-config-printer-udev


### PR DESCRIPTION
speech-dispatcher needs at least one output module; without one, turning on the screen reader just plays a dummy message.  speech-dispatcher-espeak-ng is Recommended by the Debian package.  This adds 10.7 MB to the ostree: I think a functioning screen reader is a good way to spend this space.

sound-icons is also Recommended by speech-dispatcher which uses these sounds to signal events. It adds a mere 748 KB to the ostree. https://obs-master.endlessm-sf.com/request/show/20392 adds this package to our distro; this PR depends on that request.

https://phabricator.endlessm.com/T26227