### PR TITLE
eos-convert-system: Find kernel and initramfs in new location

### DIFF
--- a/eos-tech-support/eos-convert-system
+++ b/eos-tech-support/eos-convert-system
@@ -130,10 +130,10 @@ systemd-tmpfiles --create --prefix /var/log/journal
 eos-enable-coredumps /sysroot/etc
 
 # Put the kernels/initramfs in the expected place by Debian
-for orig in ${OSTREE_DEPLOY_CURRENT}/boot/{vmlinuz,initramfs}*; do
+for orig in ${OSTREE_DEPLOY_CURRENT}/usr/lib/modules/*/{vmlinuz,initramfs}*; do
   new="${orig##*/}"
   new="${new%-*}"
-  new="${new/initramfs/initrd.img}"
+  new="${new/initramfs.img/initrd.img}"
   cp -pax "$orig" "/boot/$new"
 done
 


### PR DESCRIPTION
We've updated our kernel location to match OSTree's suggested layout,
that means the kernel isn't where this script expected it to be anymore.

This isn't certain to work as intended if there are multiple kernel module
directories, so if a developer does a bunch of non-deterministic things
like eos-dev-unlock --hotfix and installing a new kernel before running
eos-convert-system, they may not end up booting the expected kernel.

https://phabricator.endlessm.com/T27124