### PR TITLE
eos-convert-system: Append kernel version to initramfs and vmlinuz

### DIFF
--- a/eos-tech-support/eos-convert-system
+++ b/eos-tech-support/eos-convert-system
@@ -130,11 +130,10 @@ systemd-tmpfiles --create --prefix /var/log/journal
 eos-enable-coredumps /sysroot/etc
 
 # Put the kernels/initramfs in the expected place by Debian
-for orig in ${OSTREE_DEPLOY_CURRENT}/usr/lib/modules/*/{vmlinuz,initramfs}*; do
-  new="${orig##*/}"
-  new="${new%-*}"
-  new="${new/initramfs.img/initrd.img}"
-  cp -pax "$orig" "/boot/$new"
+for orig in ${OSTREE_DEPLOY_CURRENT}/usr/lib/modules/*; do
+  ver="${orig##*/}"
+  cp -pax "$orig/vmlinuz" "/boot/vmlinuz-$ver"
+  cp -pax "$orig/initramfs.img" "/boot/initrd.img-$ver"
 done
 
 if [ -L /boot/uEnv.txt ] ; then 


### PR DESCRIPTION
Turns out grub won't notice these if they're not versioned.

Multiple installed versions isn't properly handled, as we never
deploy ostree in this way.

https://phabricator.endlessm.com/T27124