### PR TITLE
Add Noto Color Emoji font

### DIFF
--- a/eos-core-depends
+++ b/eos-core-depends
@@ -84,6 +84,7 @@ fonts-khmeros
 fonts-knda
 fonts-linuxlibertine
 fonts-noto-cjk
+fonts-noto-color-emoji
 fonts-noto-mono
 fonts-ocr-a
 fonts-paktype


### PR DESCRIPTION
This is the only colour emoji font in Debian, and is the colour emoji
font recommended by the ubuntu-desktop metapackage. We would be in good
company.

Depends on <https://obs-master.endlessm-sf.com/request/show/20413> to
import this package from Debian Buster.

https://phabricator.endlessm.com/T27027