### PR TITLE
eos-enable-debian-apt: support -h and --help

### DIFF
--- a/eos-tech-support/eos-enable-debian-apt
+++ b/eos-tech-support/eos-enable-debian-apt
@@ -16,7 +16,7 @@ echo "Additionally, apt will only work after you have taken the usual steps of"
 echo "making it available (e.g. eos-convert-system, eos-dev-unlock, etc)"
 echo
 
-if [[ $# -lt 1 ]] || [[ $1 == -* ]]; then
+if [[ $# -ne 1 ]] || [[ $1 == -* ]]; then
 	echo "Usage: $0 <DEB_DISTRO>"
 	echo "DEB_DISTRO example values: stable, testing, unstable"
 	exit 1

--- a/eos-tech-support/eos-enable-debian-apt
+++ b/eos-tech-support/eos-enable-debian-apt
@@ -16,7 +16,7 @@ echo "Additionally, apt will only work after you have taken the usual steps of"
 echo "making it available (e.g. eos-convert-system, eos-dev-unlock, etc)"
 echo
 
-if [[ $# < 1 ]]; then
+if [[ $# -lt 1 ]]; then
 	echo "Usage: $0 <DEB_DISTRO>"
 	echo "DEB_DISTRO example values: stable, testing, unstable"
 	exit 1
@@ -34,7 +34,7 @@ Pin: release o=Debian
 Pin-Priority: 400
 EOF
 
-cat > /etc/apt/sources.list.d/debian-$distro.list << EOF
+cat > "/etc/apt/sources.list.d/debian-$distro.list" << EOF
 deb http://deb.debian.org/debian $distro main contrib non-free
 deb-src http://deb.debian.org/debian $distro main contrib non-free
 EOF

--- a/eos-tech-support/eos-enable-debian-apt
+++ b/eos-tech-support/eos-enable-debian-apt
@@ -16,7 +16,7 @@ echo "Additionally, apt will only work after you have taken the usual steps of"
 echo "making it available (e.g. eos-convert-system, eos-dev-unlock, etc)"
 echo
 
-if [[ $# -lt 1 ]]; then
+if [[ $# -lt 1 ]] || [[ $1 == -* ]]; then
 	echo "Usage: $0 <DEB_DISTRO>"
 	echo "DEB_DISTRO example values: stable, testing, unstable"
 	exit 1

--- a/eos-tech-support/eos-enable-debian-apt
+++ b/eos-tech-support/eos-enable-debian-apt
@@ -4,7 +4,7 @@ set -e
 echo "This script adds the Debian repository to your apt config."
 echo "The resulting configuration prefers the Endless repository where"
 echo "possible, even if a package in Endless is older than in Debian."
-echo "However, but packages not found in the Endless repo will be automatically"
+echo "However, packages not found in the Endless repo will be automatically"
 echo "downloaded from Debian".
 echo
 echo "Although this may work fine in some cases, you're likely to find issues"


### PR DESCRIPTION
The easiest way to implement this is to treat an argument beginning with
'-' as being a request for help, since no Debian distros begin with 
hyphens.

This seems preferable to configuring a repo for the Debian distro
'--help', as I just did.

I also fixed a couple of warnings from shellcheck.