### PR TITLE
Remove xapian-bridge

### DIFF
--- a/eos-core-depends
+++ b/eos-core-depends
@@ -215,7 +215,6 @@ vainfo
 vinagre
 vino
 whiptail
-xapian-bridge
 xinput
 # Assuming useful for Orca screen reader
 xbrlapi


### PR DESCRIPTION
Removes xapian-bridge from the list of dependencies of eos-core, so it
should no longer be included in the ostree. This will render all SDK1
apps nonfunctional, but we believe that there are no longer any in use,
and if there are we will port them.

https://phabricator.endlessm.com/T27277