### PR TITLE
os-depends: install spice-webdavd

### DIFF
--- a/os-depends
+++ b/os-depends
@@ -86,6 +86,7 @@ pulseaudio
 pulseaudio-module-bluetooth
 shim-efi-image-signed [amd64]
 spice-vdagent
+spice-webdavd
 sudo
 systemd-sysv
 # ARM boot loader


### PR DESCRIPTION
This (partially) enables shared folder support when running Endless OS
as a guest in Boxes, the only VM tool available on Endless OS. It adds
just 48KB (since we already ship its dependencies) and is conditionally
enabled by a udev rule which detects support for SPICE's WebDAV channel
at boot time.

https://phabricator.endlessm.com/T27317