### PR TITLE
eos-core-depends: Add gnome-software-plugin-flatpak

### DIFF
--- a/eos-core-depends
+++ b/eos-core-depends
@@ -118,6 +118,7 @@ gnome-online-accounts
 gnome-orca
 gnome-screenshot
 gnome-software
+gnome-software-plugin-flatpak
 gnome-sushi
 gnome-system-monitor
 gnome-terminal


### PR DESCRIPTION
The gnome-software rebase brings with it some new packaging decisions
from upstream, including splitting the flatpak plugin out. We need to
install that plugin by default, and it’s marginally less maintenance
work to list it here than to add it as a hard-dependency of the
`gnome-software` package in our downstream packaging there.

Signed-off-by: Philip Withnall <withnall@endlessm.com>

https://phabricator.endlessm.com/T27325