### PR TITLE
eos-initramfs-efi: Add eos-plymouth-theme

### DIFF
--- a/eos-initramfs-efi-depends
+++ b/eos-initramfs-efi-depends
@@ -1,3 +1,6 @@
+eos-plymouth-theme
+plymouth
+e2fsprogs
 eos-boot-helper
 dracut
 ostree


### PR DESCRIPTION
I broke the kernel build because plymouth isn't present when dracut
is invoked to make the efi initramfs+kernel blobs.

Adding eos-plymouth-themes here brings in several missing dependencies:
plymouth, plymouth-themes, eos-plymouth-theme-logos

https://phabricator.endlessm.com/T27042