### PR TITLE
eos-initramfs-efi: Add microcode and utilities

### DIFF
--- a/eos-initramfs-efi-depends
+++ b/eos-initramfs-efi-depends
@@ -1,8 +1,11 @@
-eos-plymouth-theme
-plymouth
+amd64-microcode
+dracut
+dracut-network
 e2fsprogs
 eos-boot-helper
-dracut
+eos-plymouth-theme
+intel-microcode
+iucode-tool
 ostree
-dracut-network
+plymouth
 systemd


### PR DESCRIPTION
Microcode utilities need to be present before running dracut so
early microcode updates can happen.  I've included:
amd64-microcode
intel-microcode
iucode-tool

Also, sort the list of dependencies.

https://phabricator.endlessm.com/T27042