### PR TITLE
Rework S905X metapackage

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -59,6 +59,7 @@ Description: Target packages of the Endless distribution for odroidu2
 Package: eos-core-s905x
 Architecture: armhf
 Depends: ${misc:Depends}, ${eos:Depends}
+Provides: eos-core-libretech_cc
 Description: Target packages of the Endless distribution for S905X-based boards
  This package depends on all packages required for the Endless OS core images
  .

--- a/s905x-depends
+++ b/s905x-depends
@@ -1,4 +1,4 @@
 # s905x hardware specific packages
 mali400-drivers-meson8
-linux-image-3.14-2-s905x
-u-boot-s905x
+linux-image-generic:arm64
+u-boot-amlogic:arm64


### PR DESCRIPTION
We're reviving our Amlogic S905X R&D efforts using mainline
u-boot and mainline kernel.

We're still sticking to armhf as the base arch (as that's the only
arch we can support for the Mali GLESv2 driver), but need to include
arm64 packages for the kernel and bootloader.

eos-core-s905x is still a good name for the metapackage, because the
packages shipped are not limited to a single specific product based
around S905X.

However, the ostree builder will need to use a product-specific
devicetree, so will use per-device platform names. Since we're starting
with the libretech_cc platform, add an alias as eos-core-libretech_cc which
is what the ostree user will use.