### PR TITLE
Revert "Introduce platfrom specific xserver-xorg-* dependency"

### DIFF
--- a/eos-core-amd64-depends
+++ b/eos-core-amd64-depends
@@ -1,2 +1,1 @@
-include os-amd64-depends
 eos-core

--- a/eos-core-i386-depends
+++ b/eos-core-i386-depends
@@ -1,2 +1,1 @@
-include os-i386-depends
 eos-core

--- a/eos-installer-meta-amd64-depends
+++ b/eos-installer-meta-amd64-depends
@@ -1,2 +1,1 @@
-include os-amd64-depends
 eos-installer-meta

--- a/eos-installer-meta-i386-depends
+++ b/eos-installer-meta-i386-depends
@@ -1,2 +1,1 @@
-include os-i386-depends
 eos-installer-meta

--- a/eos-installer-meta-nexthw-depends
+++ b/eos-installer-meta-nexthw-depends
@@ -1,2 +1,1 @@
-include os-nexthw-depends
 eos-installer-meta

--- a/os-amd64-depends
+++ b/os-amd64-depends
@@ -1,1 +1,0 @@
-xserver-xorg

--- a/os-depends
+++ b/os-depends
@@ -112,6 +112,7 @@ wpasupplicant
 xauth
 xdg-user-dirs
 xdg-user-dirs-gtk
+xserver-xorg
 xserver-xorg-input-libinput
 # Some of these are really specific to x86, but just keep them off of arm for now
 xserver-xorg-video-amdgpu [!armhf]

--- a/os-ec100-depends
+++ b/os-ec100-depends
@@ -1,2 +1,1 @@
-xserver-xorg
 xserver-xorg-video-armsoc

--- a/os-i386-depends
+++ b/os-i386-depends
@@ -1,1 +1,0 @@
-xserver-xorg

--- a/os-nexthw-depends
+++ b/os-nexthw-depends
@@ -1,1 +1,0 @@
-xserver-xorg

--- a/os-s905x-depends
+++ b/os-s905x-depends
@@ -1,2 +1,1 @@
-xserver-xorg
 xserver-xorg-video-armsoc


### PR DESCRIPTION
End support for Bitland Jerry. So, move the xserver-xorg back to
original place.

This reverts commit eafc4b93ac0e24605d16b82cedc55dcf4a2d28f1.

https://phabricator.endlessm.com/T26837