### PR TITLE
Add generic ARM64 metapackage

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -45,6 +45,18 @@ Description: Target packages of the Endless distribution for amd64
  .
  This set provides the platform specific package list for amd64.
 
+Package: eos-core-arm64
+Architecture: arm64
+Depends: ${misc:Depends}, ${eos:Depends}
+Description: Target packages of the Endless distribution for arm64
+Provides: eos-core-rpi3
+ This package depends on all packages required for the Endless OS core images
+ .
+ It is also used to help ensure proper upgrades, so it is recommended that
+ it not be removed.
+ .
+ This set provides the platform specific package list for arm64.
+
 Package: eos-core-ec100
 Architecture: armhf
 Depends: ${misc:Depends}, ${eos:Depends}

--- a/eos-core-arm64-depends
+++ b/eos-core-arm64-depends
@@ -1,0 +1,2 @@
+eos-core
+u-boot-rpi

--- a/eos-dev-kernel-arm64-depends
+++ b/eos-dev-kernel-arm64-depends
@@ -1,0 +1,1 @@
+eos-dev-kernel

--- a/eos-installer-meta-arm64-depends
+++ b/eos-installer-meta-arm64-depends
@@ -1,0 +1,1 @@
+eos-installer-meta

--- a/os-depends
+++ b/os-depends
@@ -71,6 +71,7 @@ linux-firmware
 # use the linux-signed-image variant, which contains the kernel
 # signed for UEFI.
 linux-signed-image-generic [amd64]
+linux-image-generic [arm64]
 lsb-base
 lsb-release
 # Used for the initial hardware evaluation


### PR DESCRIPTION
We're reviewing Raspberry Pi 3+ and newer R&D efforts using mainline
u-boot and mainline kernel.

https://phabricator.endlessm.com/T27446