### PR TITLE
Install nvidia-modprobe

### DIFF
--- a/os-depends
+++ b/os-depends
@@ -84,6 +84,7 @@ ntfs-3g
 nvidia-driver-bin [!armhf]
 nvidia-kernel-drivers [!armhf]
 nvidia-kernel-drivers-blob-signed [!armhf]
+nvidia-modprobe [!armhf]
 ntp
 openssh-client
 ostree


### PR DESCRIPTION
This is needed to have the NVIDIA proprietary driver working under
rootless X and Wayland.

https://phabricator.endlessm.com/T26790