### PR TITLE
eos-convert-system: Put the EFI binaries back where they came from

### DIFF
--- a/eos-tech-support/eos-convert-system
+++ b/eos-tech-support/eos-convert-system
@@ -136,6 +136,11 @@ for orig in ${OSTREE_DEPLOY_CURRENT}/usr/lib/modules/*; do
   cp -pax "$orig/initramfs.img" "/boot/initrd.img-$ver"
 done
 
+# Put the efi_binaries directory back where it came from
+if [ -d "${OSTREE_DEPLOY_CURRENT}"/usr/lib/efi_binaries ]; then
+  cp -pax "${OSTREE_DEPLOY_CURRENT}"/usr/lib/efi_binaries /boot/efi
+fi
+
 if [ -L /boot/uEnv.txt ] ; then 
   # Running on ARM
   ln -r -s /boot/vmlinuz* /boot/vmlinuz


### PR DESCRIPTION
We've moved the ostree binaries during ostree build so /boot can be
empty for PAYG images. This makes eos-convert-system put them back
where debian expects them to be.

https://phabricator.endlessm.com/T27041