### PR TITLE
eos-initramfs-efi: Add eos-payg{-nonfree} deps

### DIFF
--- a/eos-initramfs-efi-depends
+++ b/eos-initramfs-efi-depends
@@ -3,6 +3,8 @@ dracut
 dracut-network
 e2fsprogs
 eos-boot-helper
+eos-paygd
+eos-payg-nonfree
 eos-plymouth-theme
 intel-microcode
 iucode-tool


### PR DESCRIPTION
In order for eos-paygd to start in the initramfs, we need the dracut
modules in eos-payg.git and eos-payg-nonfree.git to be included in
the initramfs built for payg images. So this commit adds dependencies on
both those packages. We will also need to include the modules on the
dracut command line.

This should not be merged until after these PRs which create the dracut
modules:
- https://github.com/endlessm/eos-payg/pull/45
- https://github.com/endlessm/eos-payg-nonfree/pull/20

https://phabricator.endlessm.com/T27037