### PR TITLE
Fix eos3.6-nexthw kernel build

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -217,3 +217,10 @@ Depends: ${misc:Depends}, ${eos:Depends}
 Description: EndlessOS Development Tools for eos-toolbox container images
  This is a collection of development tools included in the eos-toolbox
  container images
+
+Package: eos-initramfs-efi
+Architecture: all
+Depends: ${misc:Depends}, ${eos:Depends}
+Description: EndlessOS Combined Initramfs and Kernel EFI Binary Requirements
+ This is a collection of packages that must be installed before dracut
+ can properly generate our combined initramfs and kernel efi binary.

--- a/eos-initramfs-efi-depends
+++ b/eos-initramfs-efi-depends
@@ -1,3 +1,6 @@
+eos-plymouth-theme
+plymouth
+e2fsprogs
 eos-boot-helper
 dracut
 ostree

--- a/eos-initramfs-efi-depends
+++ b/eos-initramfs-efi-depends
@@ -1,0 +1,5 @@
+eos-boot-helper
+dracut
+ostree
+dracut-network
+systemd

--- a/eos-initramfs-efi-depends
+++ b/eos-initramfs-efi-depends
@@ -1,8 +1,11 @@
-eos-plymouth-theme
-plymouth
+amd64-microcode
+dracut
+dracut-network
 e2fsprogs
 eos-boot-helper
-dracut
+eos-plymouth-theme
+intel-microcode
+iucode-tool
 ostree
-dracut-network
+plymouth
 systemd


### PR DESCRIPTION
To fix the eos3.6-nexthw kernel build error "nothing provides eos-initramfs-efi", we need to have eos-initramfs-efi package.

https://phabricator.endlessm.com/T27042