### PR TITLE
os-depends: Add systemd-boot-signed

### DIFF
--- a/os-depends
+++ b/os-depends
@@ -102,6 +102,8 @@ smartmontools
 spice-vdagent
 spice-webdavd
 sudo
+# Used for booting unified kernel EFI image on PAYG
+systemd-boot-signed [amd64]
 systemd-sysv
 # ARM boot loader
 u-boot-tools [armhf]


### PR DESCRIPTION
This will be used for PAYG images to create a unified kernel EFI image.

https://phabricator.endlessm.com/T27042