### PR TITLE
Add git-buildpackage to eos-dev-depends

### DIFF
--- a/eos-dev-depends
+++ b/eos-dev-depends
@@ -29,6 +29,7 @@ exuberant-ctags
 gdb
 git
 gitk
+git-buildpackage
 gnome-common
 gnome-devel-docs
 gtk-doc-tools


### PR DESCRIPTION
It's the tool that the Debian GNOME team uses, but it's
not a dependency of any other Debian tool.

https://phabricator.endlessm.com/T27741