### PR TITLE
eos-core-depends: Add efitools for PAYG secure boot key management

### DIFF
--- a/eos-core-depends
+++ b/eos-core-depends
@@ -38,6 +38,8 @@ dnsmasq-base
 # For brasero video DVD functionality
 dvdauthor
 e2fsprogs-l10n
+# For PAYG secure boot key management
+efitools [amd64]
 # For flatpak-builder
 elfutils
 eog


### PR DESCRIPTION
We need efitools to make authenticated efi variable updates for
managing secure boot keys (PK, KEK, db) on PAYG systems.

https://phabricator.endlessm.com/T27106