### PR TITLE
Add ostree-boot to os-depends|eos-initramfs-efi

### DIFF
--- a/eos-initramfs-efi-depends
+++ b/eos-initramfs-efi-depends
@@ -9,5 +9,6 @@ eos-plymouth-theme
 intel-microcode
 iucode-tool
 ostree
+ostree-boot
 plymouth
 systemd

--- a/os-depends
+++ b/os-depends
@@ -88,6 +88,7 @@ nvidia-modprobe [amd64]
 ntp
 openssh-client
 ostree
+ostree-boot
 p7zip-full
 parted
 # Used for the initial hardware evaluation


### PR DESCRIPTION
Depends on https://github.com/endlessm/ostree/pull/159.

https://phabricator.endlessm.com/T27607