### PR TITLE
Add gvfs-fuse to core depends

### DIFF
--- a/eos-core-depends
+++ b/eos-core-depends
@@ -130,6 +130,7 @@ gsfonts
 gstreamer1.0-gl
 gvfs-backends
 gvfs-bin
+gvfs-fuse
 hplip
 htop
 ibus-anthy


### PR DESCRIPTION
Allows access to network and device (eg MTP) filesystems from
applications such as VLC and Shotwell that do not access the
filesystem via GVfs.

https://phabricator.endlessm.com/T26298