### PR TITLE
Add baobab to core depends

### DIFF
--- a/eos-core-depends
+++ b/eos-core-depends
@@ -21,6 +21,7 @@ apt-utils
 avahi-daemon
 # For field debugging
 avahi-utils
+baobab
 bluez-obexd
 bolt
 brasero


### PR DESCRIPTION
Provide GNOME Disk Usage Analyzer as a stopgap until GNOME Usage
reaches better maturity.

https://phabricator.endlessm.com/T27873