### PR TITLE
eos-add-to-desktop: fix dekstop typo in comment

### DIFF
--- a/eos-dev-depends
+++ b/eos-dev-depends
@@ -17,7 +17,6 @@ automake
 bash-completion
 build-essential
 ccache
-dconf-editor
 debian-archive-keyring
 debian-keyring
 debootstrap

--- a/eos-tech-support/eos-add-to-desktop
+++ b/eos-tech-support/eos-add-to-desktop
@@ -1,7 +1,7 @@
 #!/bin/bash -e
 
-# Adds an application to the dekstop
-# The appname.dekstop file must already exist (typically in
+# Adds an application to the desktop
+# The appname.desktop file must already exist (typically in
 # /usr/share/applications or ~/.local/share/applications)
 
 if [ $# -lt 1 ] || [ $1 == "-h" ] || [ $1 == "--help" ]; then


### PR DESCRIPTION
Spotted while checking whether I should include `.desktop` in an email subject :-)