### PR TITLE
eos-core: install python3-venv

### DIFF
--- a/eos-core-depends
+++ b/eos-core-depends
@@ -187,6 +187,7 @@ ppp
 printer-driver-all-enforce
 python3-flapjack
 python3-pip
+python3-venv
 rhythmbox (>= 2.99.1)
 rhythmbox-plugins
 rtkit


### PR DESCRIPTION
In the spirit of a5d94b4a (which added pip to the ostree), allow people
to create Python virtual environments on unconverted Endless OS systems.
This package (and its dependency, python3.7-venv, which actually
contains the code) adds 44 kB to the installed system.

https://phabricator.endlessm.com/T28826