### PR TITLE
eos-diagnostics: include 'zramctl' output

### DIFF
--- a/eos-tech-support/eos-diagnostics
+++ b/eos-tech-support/eos-diagnostics
@@ -562,7 +562,8 @@ let diagnostics = [
         hardwareInfo: true,
         content: function() {
             return trySpawn('free -mh') + '\n' +
-                   tryReadFile('/proc/meminfo');
+                   tryReadFile('/proc/meminfo') + '\n' +
+                   trySpawn('zramctl --output-all');
         },
     },
     {


### PR DESCRIPTION
On my system, this looks like:

```
NAME       DISKSIZE  DATA COMPR ALGORITHM STREAMS ZERO-PAGES TOTAL MEM-LIMIT MEM-USED MIGRATED MOUNTPOINT
/dev/zram0      23G 51.8M  4.1M lzo-rle         8       7765  7.6M        0B   192.5M      30B [SWAP]
```

I think it may be helpful for interpreting the RAM and "swap" usage
figures from 'free -mh'.