### PR TITLE
eos-core: Drop u2f-hidraw-policy

### DIFF
--- a/eos-core-depends
+++ b/eos-core-depends
@@ -210,7 +210,6 @@ tracker
 tracker-miner-fs
 ttf-ancient-fonts
 ttf-femkeklaver
-u2f-hidraw-policy
 # For rootless podman
 uidmap
 unrar


### PR DESCRIPTION
The same functionality provided by this package is now integrated in
udev 244, so we can drop it.

https://phabricator.endlessm.com/T29320