### PR TITLE
eos-core-depends: Add gnome-shell-extension-appindicator

### DIFF
--- a/eos-core-depends
+++ b/eos-core-depends
@@ -120,6 +120,7 @@ gnome-logs
 gnome-online-accounts
 gnome-orca
 gnome-screenshot
+gnome-shell-extension-appindicator
 gnome-software
 gnome-software-plugin-flatpak
 gnome-sushi


### PR DESCRIPTION
https://phabricator.endlessm.com/T28777