### PR TITLE
Include the eos-watermark-extension package by default

### DIFF
--- a/eos-core-depends
+++ b/eos-core-depends
@@ -65,6 +65,7 @@ eos-metrics-instrumentation
 eos-phone-home
 eos-speedwagon
 eos-updater-tools
+eos-watermark-extension
 evince
 evolution
 # For spam filtering


### PR DESCRIPTION
This feature is being moved from GNOME Shell to an extension
shipped by default.

Notice that this depends on https://github.com/endlessm/eos-build/pull/1090 -- the package doesn't exist yet.

https://phabricator.endlessm.com/T28778