### PR TITLE
Include the eos-hack-extension package by default

### DIFF
--- a/eos-core-depends
+++ b/eos-core-depends
@@ -56,6 +56,7 @@ eos-exploration-center
 eos-flatpak-autoinstall
 eos-gates
 eos-google-chrome-helper [amd64]
+eos-hack-extension
 eos-install-app-helper [amd64]
 eos-installer
 eos-kalite-system-helper


### PR DESCRIPTION
This feature is being moved from GNOME Shell to an extension
shipped by default.

https://phabricator.endlessm.com/T28568