### PR TITLE
Include the pipewire daemon in the default distribution

### DIFF
--- a/eos-core-depends
+++ b/eos-core-depends
@@ -182,6 +182,7 @@ openprinting-ppds
 openssh-server
 # For flatpak-builder
 patch
+pipewire
 podman
 podman-docker
 # For modem support


### PR DESCRIPTION
It isn’t a hard dependency of the libpipewire client library, so has to
be explicitly pulled into the distribution.

Signed-off-by: Philip Withnall <withnall@endlessm.com>

https://phabricator.endlessm.com/T22259