### PR TITLE
Include the parental controls UI in the default distribution

### DIFF
--- a/eos-core-depends
+++ b/eos-core-depends
@@ -174,6 +174,8 @@ libnss-systemd
 libpam-gnome-keyring
 # Assumed useful for apps that use libsasl2
 libsasl2-modules
+# Parental controls
+malcontent-control
 modemmanager
 nautilus
 nautilus-extension-brasero


### PR DESCRIPTION
Signed-off-by: Philip Withnall <withnall@endlessm.com>

https://phabricator.endlessm.com/T29459