### PR TITLE
eos-write-live-image: Allow provisioning of persistent storage space

### DIFF
--- a/eos-tech-support/eos-write-live-image
+++ b/eos-tech-support/eos-write-live-image
@@ -19,7 +19,7 @@ if [ ! -f "$EOS_DOWNLOAD_IMAGE" ]; then
     EOS_DOWNLOAD_IMAGE='eos-download-image'
 fi
 
-ARGS=$(getopt -o o:x:lp:r:nms:wL:fh \
+ARGS=$(getopt -o o:x:lp:r:nms:wL:fPh \
     -l os-image: \
     -l windows-tool: \
     -l latest \
@@ -34,6 +34,7 @@ ARGS=$(getopt -o o:x:lp:r:nms:wL:fh \
     -l label: \
     -l force \
     -l debug \
+    -l persistent \
     -l help \
     -n "$0" -- "$@")
 eval set -- "$ARGS"
@@ -50,6 +51,7 @@ PERSONALITY=base
 PRODUCT=eos
 LABEL=
 DEBUG=
+PERSISTENT=
 
 usage() {
     local SELF
@@ -77,6 +79,7 @@ Options:
                              prevents installing it later)
         --no-bios            Do not create a BIOS boot partition
     -f, --force              don't ask to proceed before writing
+    -P, --persistent         Allocate space for persistent storage
     -h, --help               Show this message
 
 Developer options (you probably don't want to use these):
@@ -175,6 +178,10 @@ while true; do
         -f|--force)
             shift
             FORCE=true
+            ;;
+        -P|--persistent)
+            shift
+            PERSISTENT=true
             ;;
         --no-bios)
             shift
@@ -482,6 +489,17 @@ if [ "$EXPAND" ]; then
         echo "Expanding the image from $IMAGE_BYTES to $SIZE bytes"
         truncate --size "$SIZE" "${DIR_IMAGES_ENDLESS}/endless.img"
     fi
+fi
+
+if [ "$PERSISTENT" ]; then
+    # we need 512 byte alignment for device mapper, so let's do this in KBytes.
+    FREE_SPACE_KBYTES=$(df -P -B1 "$DIR_IMAGES_ENDLESS" | awk 'NR==2 {print $4}')
+    let FREE_SPACE_KBYTES=FREE_SPACE_KBYTES/1024
+    echo "Creating ${FREE_SPACE_KBYTES}K bytes persistent storage file."
+    echo "This will not be fast."
+
+    echo "endless_live_storage_marker" > "${DIR_IMAGES_ENDLESS}/persistent.img"
+    truncate -s ${FREE_SPACE_KBYTES}K "${DIR_IMAGES_ENDLESS}/persistent.img"
 fi
 
 echo


### PR DESCRIPTION
We now have a command line option to fill the eoslive partition with
a file for persistent storage space.

Currently this is not a fast operation - truncating the file to size
appears to be slow, yet not quite as slow as zero filling the space
would be.  It is hoped that this will be faster in the future with
a non-FUSE exfat driver.  In that case we can reconsider whether
this mode of operation should be default.

Untested on NTFS.

https://phabricator.endlessm.com/T14891