### PR TITLE
core: Drop pipewire

### DIFF
--- a/eos-core-depends
+++ b/eos-core-depends
@@ -185,7 +185,6 @@ openprinting-ppds
 openssh-server
 # For flatpak-builder
 patch
-pipewire
 podman
 podman-docker
 # For modem support


### PR DESCRIPTION
This is not ready to replace PulseAudio just yet, and it does not seem
to be compatible side-by-side with PulseAudio.

https://phabricator.endlessm.com/T22259