### PR TITLE
Add Amlogic U-Boot dependency to arm64 OSTree

### DIFF
--- a/eos-core-arm64-depends
+++ b/eos-core-arm64-depends
@@ -1,2 +1,3 @@
 eos-core
 u-boot-rpi
+u-boot-amlogic


### PR DESCRIPTION
Add corresponding u-boot to make khadas VIM2 boot.

https://phabricator.endlessm.com/T30324