### PR TITLE
core: Temporarily disable eos-hack-extension

### DIFF
--- a/eos-core-depends
+++ b/eos-core-depends
@@ -55,7 +55,7 @@ eos-exploration-center
 eos-flatpak-autoinstall
 eos-gates
 eos-google-chrome-helper [amd64]
-eos-hack-extension
+# eos-hack-extension
 eos-install-app-helper [amd64]
 eos-installer
 eos-kalite-system-helper


### PR DESCRIPTION
Leave it commented as a painful reminder that it needs to be uncommented before 3.9.

https://phabricator.endlessm.com/T30172