### PR TITLE
core: Add eos-desktop-extension

### DIFF
--- a/eos-core-depends
+++ b/eos-core-depends
@@ -50,6 +50,7 @@ eos-b43fw-install
 eos-browser-tools
 eos-chrome-plugin-updater [amd64 armhf]
 eos-codecs-manager
+eos-desktop-extension
 eos-event-recorder-daemon
 eos-exploration-center
 eos-flatpak-autoinstall


### PR DESCRIPTION
Add eos-desktop-extension to the list of core-depends
packages.

https://phabricator.endlessm.com/T30540