### PR TITLE
core: Enable eos-hack-extension again

### DIFF
--- a/eos-core-depends
+++ b/eos-core-depends
@@ -56,7 +56,7 @@ eos-exploration-center
 eos-flatpak-autoinstall
 eos-gates
 eos-google-chrome-helper [amd64]
-# eos-hack-extension
+eos-hack-extension
 eos-install-app-helper [amd64]
 eos-installer
 eos-kalite-system-helper


### PR DESCRIPTION
The current hack extension master is updated to work with the
gnome-shell 3.37.3 so it can be added safely to the list of deps.