### PR TITLE
eos-write-live-image: Invert --persistent-size

### DIFF
--- a/eos-tech-support/eos-write-live-image
+++ b/eos-tech-support/eos-write-live-image
@@ -55,7 +55,6 @@ FORCE=
 PERSONALITY=base
 PRODUCT=eos
 LABEL=
-DEBUG=
 PERSISTENT=
 PERSISTENT_SIZE=
 
@@ -214,7 +213,6 @@ while true; do
         --debug)
             shift
             set -x
-            DEBUG=--debug
             ;;
         -h|--help)
             usage

--- a/eos-tech-support/eos-write-live-image
+++ b/eos-tech-support/eos-write-live-image
@@ -37,7 +37,7 @@ ARGS=$(getopt -o o:x:lp:r:nms:wL:fPe:h \
     -l force \
     -l debug \
     -l persistent \
-    -l persistent-size: \
+    -l free-space: \
     -l extra-data: \
     -l help \
     -n "$0" -- "$@")
@@ -56,7 +56,7 @@ PERSONALITY=base
 PRODUCT=eos
 LABEL=
 PERSISTENT=
-PERSISTENT_SIZE=
+PERSISTENT_FREE_SPACE=
 
 usage() {
     local SELF
@@ -84,13 +84,12 @@ Options:
                              prevents installing it later)
         --no-bios            Do not create a BIOS boot partition
     -f, --force              don't ask to proceed before writing
-    -P, --persistent         Allocate space for persistent storage, always leaving
-                             between 16-32MB for logs from the Endless OS
+    -P, --persistent         Allocate space for persistent storage, leaving a
+                             few megabytes for logs from the Endless OS
                              installer tool for Windows
-    -S, --persistent-size    Size to allocate for persistent storage, in megabytes
-                             (min 1024, max and default is to use all available
-                             space for persistent storage, still leaving 16-32MB
-                             for logs)
+    -S, --free-space SIZE    With --persistent, leave SIZE megabytes free on
+                             the partition, rather than consuming almost all
+                             free space
     -e, --extra-data PATH    A local path to copy to the live partition, it can
                              be used multiple times
     -h, --help               Show this message
@@ -201,9 +200,9 @@ while true; do
             shift
             PERSISTENT=true
             ;;
-        -S|--persistent-size)
+        -S|--free-space)
             shift
-            PERSISTENT_SIZE="$1"
+            PERSISTENT_FREE_SPACE="$1"
             shift
             ;;
         --no-bios)
@@ -537,35 +536,28 @@ if [ "$EXPAND" ]; then
 fi
 
 if [ "$PERSISTENT" ]; then
-    # we want at least 16M free for log files, but more importantly we want at
-    # least 1G of free space if we're to make any persistent storage at all.
-    # So, let's have df report the size in 16M blocks, leave two free for logs,
-    # and only make space if we have more than 66 in all (because 64*16 is 1024).
-    # These numbers seem high because df always rounds up, so if we had 65
-    # blocks free and made a 64 block persistent storage file, we could end
-    # up with a single free byte.
-    FREE_BLOCKS=$(df -P -B16M "$DIR_IMAGES_ENDLESS" | awk 'NR==2 {print $4}')
-
-    if [ "$PERSISTENT_SIZE" ] && [ "$PERSISTENT_SIZE" -lt "1024" ]; then
-        echo "The specified persistent storage size is less than 1024MB, using 1024MB."
-        PERSISTENT_SIZE="1024"
+    # We always want at least 16MB for log files, regardless of what the user
+    # asked for.
+    if (( "${PERSISTENT_FREE_SPACE:-0}" < 16 )); then
+        PERSISTENT_FREE_SPACE=16
     fi
 
-    if [ "$FREE_BLOCKS" -gt "66" ]; then
-        let FREE_SPACE_MBYTES=(FREE_BLOCKS - 2)*16
+    FREE_MB=$(df -P -B1M "$DIR_IMAGES_ENDLESS" | awk 'NR==2 {print $4}')
+    # df always rounds up, so leave an extra 1MB to compensate.
+    PERSISTENT_SIZE_MB=$(( FREE_MB - (PERSISTENT_FREE_SPACE + 1) ))
 
-        if [ "$PERSISTENT_SIZE" ] && [ "$PERSISTENT_SIZE" -lt "$FREE_SPACE_MBYTES" ]; then
-            FREE_SPACE_MBYTES=$PERSISTENT_SIZE
-        fi
 
-        echo "Creating ${FREE_SPACE_MBYTES}M bytes persistent storage file."
-        echo "This will not be fast."
-
-        echo "endless_live_storage_marker" > "${DIR_IMAGES_ENDLESS}/persistent.img"
-        truncate -s ${FREE_SPACE_MBYTES}M "${DIR_IMAGES_ENDLESS}/persistent.img"
-    else
-        echo "Not enough free space to create persistent storage"
+    if (( PERSISTENT_SIZE_MB < 1024 )); then
+        echo "Not enough free space to create persistent storage" >&2
+        cleanup
+        exit 1
     fi
+
+    echo "Creating ${PERSISTENT_SIZE_MB}M bytes persistent storage file."
+    echo "This will not be fast."
+
+    echo "endless_live_storage_marker" > "${DIR_IMAGES_ENDLESS}/persistent.img"
+    truncate -s ${PERSISTENT_SIZE_MB}M "${DIR_IMAGES_ENDLESS}/persistent.img"
 fi
 
 echo

--- a/eos-tech-support/eos-write-live-image
+++ b/eos-tech-support/eos-write-live-image
@@ -275,7 +275,7 @@ if [ "$EXPAND" ]; then
 fi
 
 for command in "${!dependencies[@]}"; do
-    if ! which "$command" >/dev/null 2>&1; then
+    if ! command -v "$command" >/dev/null 2>&1; then
         echo "$command is not installed... aborting!" >&2
         echo "Try 'sudo apt-get install ${dependencies[$command]}'" >&2
         exit 1
@@ -343,7 +343,7 @@ if [ ! "$FORCE" ]; then
     fi
 fi
 
-if [ ! -z "$FETCH_LATEST" ]; then
+if [ -n "$FETCH_LATEST" ]; then
     if [ -z "$OS_IMAGE" ]; then
         OS_IMAGE=$($EOS_DOWNLOAD_IMAGE --personality "${PERSONALITY}" --product "${PRODUCT}")
         if [ -z "$LABEL" ]; then
@@ -459,7 +459,7 @@ DIR_IMAGES_ENDLESS="${DIR_IMAGES}/endless"
 mkdir "$DIR_IMAGES_ENDLESS"
 unzip -q -d "${DIR_IMAGES_ENDLESS}" "${BOOT_ZIP}" "grub/*"
 
-if [ ! -z "$DIR_EFI" ]; then
+if [ -n "$DIR_EFI" ]; then
     unzip -q -d "${DIR_EFI}" "${BOOT_ZIP}" "EFI/*"
 fi
 
@@ -511,26 +511,26 @@ if [ "$EXPAND" ]; then
     FREE_SPACE_BYTES=$(df -P -B1 "$DIR_IMAGES_ENDLESS" | awk 'NR==2 {print $4}')
 
     if [ -n "$SIZE" ]; then
-        if [ $SIZE -lt $IMAGE_BYTES ]; then
+        if [ "$SIZE" -lt "$IMAGE_BYTES" ]; then
             echo "Cannot expand the image to $SIZE bytes, minimum size is $IMAGE_BYTES bytes" >&2
             cleanup
             exit 1
         fi
 
         # Expand the image to the provided size
-        EXTRA_BYTES=$(($SIZE - $IMAGE_BYTES))
+        EXTRA_BYTES=$((SIZE - IMAGE_BYTES))
 
-        if [ $EXTRA_BYTES -gt $FREE_SPACE_BYTES ]; then
+        if [ "$EXTRA_BYTES" -gt "$FREE_SPACE_BYTES" ]; then
             echo "Cannot expand the image to $SIZE bytes, only $FREE_SPACE_BYTES bytes available" >&2
             cleanup
             exit 1
         fi
     else
         # Expand the image to take all the space on the drive
-        SIZE=$(($IMAGE_BYTES + $FREE_SPACE_BYTES))
+        SIZE=$((IMAGE_BYTES + FREE_SPACE_BYTES))
     fi
 
-    if [ $SIZE -gt $IMAGE_BYTES ]; then
+    if [ $SIZE -gt "$IMAGE_BYTES" ]; then
         echo "Expanding the image from $IMAGE_BYTES to $SIZE bytes"
         truncate --size "$SIZE" "${DIR_IMAGES_ENDLESS}/endless.img"
     fi


### PR DESCRIPTION
The goal of this parameter was to allow a certain amount of disk space
to be left free for changes to the Kolibri homedir.  However this means
that you have to know what the free space on the partition will be
before you run the command that populates the partition.

Instead, accept a --free-space parameter, and use the maximum of this
value (if provided) and 17 MB as the free space. This allows the caller
to directly request what they want: persistent.img filling all but X of
the free space.

Also fix some linter warnings. Actually `shellcheck` can't parse the current code at all:

```
In eos-tech-support/eos-write-live-image line 541:
if [ "$PERSISTENT" ]; then
                      ^-- SC1009: The mentioned syntax error was in this then clause.


In eos-tech-support/eos-write-live-image line 556:
    if [ "$FREE_BLOCKS" -gt "66" ]; then
    ^-- SC1046: Couldn't find 'fi' for this 'if'.
    ^-- SC1073: Couldn't parse this if expression. Fix to allow more checks.


In eos-tech-support/eos-write-live-image line 557:
        let FREE_SPACE_MBYTES=(FREE_BLOCKS - 2)*16
                              ^-- SC1036: '(' is invalid here. Did you forget to escape it?
                              ^-- SC1047: Expected 'fi' matching previously mentioned 'if'.
                              ^-- SC1072: Expected 'fi'. Fix any mentioned problems and try again.

For more information:
  https://www.shellcheck.net/wiki/SC1046 -- Couldn't find 'fi' for this 'if'.
  https://www.shellcheck.net/wiki/SC1036 -- '(' is invalid here. Did you forg...
  https://www.shellcheck.net/wiki/SC1047 -- Expected 'fi' matching previously...
```

## TODO

- [x] TEST THIS CODE IN ANY WAY

https://phabricator.endlessm.com/T30677

