### PR TITLE
core: Drop eos-speedwagon

### DIFF
--- a/eos-core-depends
+++ b/eos-core-depends
@@ -64,7 +64,6 @@ eos-media
 eos-metrics-instrumentation
 eos-panel-extension
 eos-phone-home
-eos-speedwagon
 eos-onboarding-extension
 eos-updater-tools
 eos-watermark-extension


### PR DESCRIPTION
We are removing the speedwagon integration on 3.9.

https://phabricator.endlessm.com/T30293