### PR TITLE
eos-tech-support: Add eos-link-feedback.desktop

### DIFF
--- a/debian/eos-tech-support.install
+++ b/debian/eos-tech-support.install
@@ -1,1 +1,2 @@
 eos-tech-support/eos-* usr/bin
+eos-tech-support/data/*.desktop usr/share/applications

--- a/eos-tech-support/data/eos-link-feedback.desktop
+++ b/eos-tech-support/data/eos-link-feedback.desktop
@@ -1,0 +1,7 @@
+[Desktop Entry]
+Version=1.0
+Name=Feedback
+Type=Application
+Exec=gio open https://community.endlessos.com/
+Categories=Utility;
+NoDisplay=true


### PR DESCRIPTION
This is used by both our help pages and the Shell panel user menu to point users to our community forum for feedback.

This currently (3.8) lives in the Shell but we decided to move it here so we don't have to rebase this patch on every Shell rebase.

https://phabricator.endlessm.com/T30172