### PR TITLE
core: Drop eos-exploration-center

### DIFF
--- a/eos-core-depends
+++ b/eos-core-depends
@@ -52,7 +52,6 @@ eos-chrome-plugin-updater [amd64 armhf]
 eos-codecs-manager
 eos-desktop-extension
 eos-event-recorder-daemon
-eos-exploration-center
 eos-flatpak-autoinstall
 eos-gates
 eos-google-chrome-helper [amd64]


### PR DESCRIPTION
We are removing the exploration center extension on 3.9.

https://phabricator.endlessm.com/T30720