### PR TITLE
Add Rockchip U-Boot dependency to arm64 OSTree

### DIFF
--- a/eos-core-arm64-depends
+++ b/eos-core-arm64-depends
@@ -1,3 +1,4 @@
 eos-core
 u-boot-rpi
 u-boot-amlogic
+u-boot-rockchip


### PR DESCRIPTION
Add corresponding u-boot to make PINEBOOK Pro boot.

https://phabricator.endlessm.com/T30613