### PR TITLE
eos-write-live-image: Implement -S SIZE flag

### DIFF
--- a/eos-tech-support/eos-write-live-image
+++ b/eos-tech-support/eos-write-live-image
@@ -21,7 +21,7 @@ if [ ! -f "$EOS_DOWNLOAD_IMAGE" ]; then
     EOS_DOWNLOAD_IMAGE='eos-download-image'
 fi
 
-ARGS=$(getopt -o o:x:lp:r:nms:wL:fPe:h \
+ARGS=$(getopt -o o:x:lp:r:nms:wL:fPS:e:h \
     -l os-image: \
     -l windows-tool: \
     -l latest \


### PR DESCRIPTION
The -S short flag was previously documented to mean the same as
--persistent-size, introduced in b829924. 68f6bd2 replaced
--persistent-size with --free-space but kept -S as the short synonym.
However, -S was never added to the getopt invocation.

https://phabricator.endlessm.com/T30677
