### PR TITLE
eos-write-live-image: Never create BIOS Boot partition

### DIFF
--- a/eos-tech-support/eos-write-live-image
+++ b/eos-tech-support/eos-write-live-image
@@ -394,8 +394,6 @@ else
 
     # We want the data partition, "eoslive", to occupy all the space on the disk
     # after the UEFI partition and the gap where the BIOS bootloader lives.
-    # But, we also want it to be numbered first: apparently Windows will only
-    # mount the partition numbered first, regardless of where it is on the disk.
     #
     # It is important that the offset of the BIOS boot gap matches that
     # used in the Endless OS image builder, since it is embedded in the GRUB
@@ -406,8 +404,8 @@ else
     # Windows offers to format such partitions, so we don't do this any more.
     # We leave a 1 MiB gap where the partition should be.
     sfdisk --label gpt "$OUTPUT" <<EFI_PARTITIONS
-2 : start=2048, size=62MiB, type=$PARTITION_SYSTEM_GUID
-1 : start=131072, name=eoslive, type=$PARTITION_BASIC_DATA_GUID
+1 : start=2048, size=62MiB, type=$PARTITION_SYSTEM_GUID
+2 : start=131072, name=eoslive, type=$PARTITION_BASIC_DATA_GUID
 EFI_PARTITIONS
 
     udevadm settle

--- a/eos-tech-support/eos-write-live-image
+++ b/eos-tech-support/eos-write-live-image
@@ -52,7 +52,6 @@ MBR=
 EXPAND=
 SIZE=
 WRITABLE=
-BIOS=true
 WINDOWS_TOOL_PROVIDED=
 EXTRA_DATA_PATHS=()
 FORCE=
@@ -86,7 +85,6 @@ Options:
         --fill               Expand the image to fill the target disk
     -w, --writable           Allow image to be modified when run (which
                              prevents installing it later)
-        --no-bios            Do not create a BIOS boot partition
     -f, --force              don't ask to proceed before writing
     -P, --persistent         Allocate space for persistent storage, leaving a
                              few megabytes for logs from the Endless OS
@@ -202,9 +200,8 @@ while true; do
             PERSISTENT_FREE_SPACE="$1"
             shift
             ;;
-        --no-bios)
+        --no-bios)  # Undocumented, accepted for backwards-compatibility
             shift
-            BIOS=
             ;;
         --debug)
             shift
@@ -289,11 +286,6 @@ if [ -z "$FETCH_LATEST" ]; then
     fi
 fi
 
-if [ ! "$BIOS" ] && [ "$MBR" ]; then
-    echo "--no-bios and --mbr cannot be used together" >&2
-    exit 1
-fi
-
 if [ -n "$SIZE" ]; then
     SIZE_DESC=$SIZE
 else
@@ -309,7 +301,6 @@ echo
 echo "       Endless OS image: ${OS_IMAGE:-latest $PRODUCT $PERSONALITY image}"
 echo "  Installer for Windows: ${WINDOWS_TOOL:-latest release}"
 echo "      Image target size: ${SIZE_DESC}"
-echo "  Create BIOS partition: ${BIOS:-false}"
 echo "                 Target: ${OUTPUT}"
 echo
 
@@ -382,7 +373,7 @@ echo "Preparing $OUTPUT..."
 # to disk A, overwrite disk A with this tool, write I to disk B, then try
 # to boot from B with A still plugged in, the "UUID" from the stale ISO9660
 # header on A is still read by the kernel and taken as the UUID for disk A
-# as a whole, and its BIOS boot partition too (for good measure). This
+# as a whole. This
 # confuses eos-image-boot-setup into trying to mount a partition on disk A
 # rather than B.
 dd if=/dev/zero of="$OUTPUT" bs=4096 count=2 seek=8
@@ -399,37 +390,31 @@ MBR_PARTITIONS
 else
     # https://en.wikipedia.org/wiki/GUID_Partition_Table#Partition_type_GUIDs
     PARTITION_SYSTEM_GUID="c12a7328-f81f-11d2-ba4b-00a0c93ec93b"
-    PARTITION_BIOS_BOOT_GUID="21686148-6449-6E6F-744E-656564454649"
     PARTITION_BASIC_DATA_GUID="ebd0a0a2-b9e5-4433-87c0-68b6b72699c7"
 
     # We want the data partition, "eoslive", to occupy all the space on the disk
-    # after the UEFI and BIOS boot partitions. But, we also want it to be numbered
-    # first: apparently Windows will only mount the partition numbered first,
-    # regardless of where it is on the disk.
+    # after the UEFI partition and the gap where the BIOS bootloader lives.
+    # But, we also want it to be numbered first: apparently Windows will only
+    # mount the partition numbered first, regardless of where it is on the disk.
     #
-    # It is important that the offset of the BIOS boot partition matches that
+    # It is important that the offset of the BIOS boot gap matches that
     # used in the Endless OS image builder, since it is embedded in the GRUB
     # image.
-    if [ "$BIOS" ]; then
-        sfdisk --label gpt "$OUTPUT" <<EFI_PARTITIONS
+    #
+    # The more standards-compliant thing to do is to create a partition for the
+    # BIOS bootloader, with GUID 21686148-6449-6E6F-744E-656564454649. However,
+    # Windows offers to format such partitions, so we don't do this any more.
+    # We leave a 1 MiB gap where the partition should be.
+    sfdisk --label gpt "$OUTPUT" <<EFI_PARTITIONS
 2 : start=2048, size=62MiB, type=$PARTITION_SYSTEM_GUID
-3 : size=1MiB, type=$PARTITION_BIOS_BOOT_GUID
-1 : name=eoslive, type=$PARTITION_BASIC_DATA_GUID
+1 : start=131072, name=eoslive, type=$PARTITION_BASIC_DATA_GUID
 EFI_PARTITIONS
-    else
-        sfdisk --label gpt "$OUTPUT" <<EFI_PARTITIONS
-2 : start=2048, size=62MiB, type=$PARTITION_SYSTEM_GUID
-1 : name=eoslive, type=$PARTITION_BASIC_DATA_GUID
-EFI_PARTITIONS
-    fi
+
     udevadm settle
     partprobe "$OUTPUT"
     PARTMAP=$(sfdisk --dump "$OUTPUT")
     DEVICE_IMAGES=$(find_by_type "$PARTMAP" "$PARTITION_BASIC_DATA_GUID")
     DEVICE_EFI=$(find_by_type "$PARTMAP" "$PARTITION_SYSTEM_GUID")
-    if [ "$BIOS" ]; then
-        DEVICE_BIOS=$(find_by_type "$PARTMAP" "$PARTITION_BIOS_BOOT_GUID")
-    fi
 fi
 
 # Give udev a chance to notice the new partitions
@@ -573,10 +558,9 @@ else
     # Bootstrap code, built to jump to the offset of BIOS boot partition
     unzip -q -p "${BOOT_ZIP}" "live/boot.img" | dd of="${OUTPUT}" bs=446 count=1
     udevadm settle  # udev recreates device files after any write to the device
-    # The rest of GRUB goes into a dedicated BIOS-boot partition
-    if [ "$BIOS" ]; then
-        unzip -q -p "${BOOT_ZIP}" "live/core.img" | dd of="${DEVICE_BIOS}" bs=512
-    fi
+    # The rest of GRUB goes into a space between the ESP and the data partition,
+    # as documented above.
+    unzip -q -p "${BOOT_ZIP}" "live/core.img" | dd of="${OUTPUT}" bs=512 seek=129024 count=2048
 fi
 
 udevadm settle

--- a/eos-tech-support/eos-write-live-image
+++ b/eos-tech-support/eos-write-live-image
@@ -10,7 +10,11 @@ set -o pipefail
 # the image partition. Additional images copied to the image partition will be
 # detected by the installer, but will not be bootable.
 
-ISO_MOUNTPOINT="/run/media/eos-write-live-image"
+MOUNTS=/run/media/eos-write-live-image
+ISO_MOUNTPOINT=$MOUNTS/iso
+ESP_MOUNTPOINT=$MOUNTS/esp
+EOSLIVE_MOUNTPOINT=$MOUNTS/eoslive
+
 
 EOS_WRITE_IMAGE=$(dirname "$0")/eos-write-image
 if [ ! -f "$EOS_WRITE_IMAGE" ]; then
@@ -108,25 +112,18 @@ function check_exists() {
     fi
 }
 
+function cleanup_mountpoint() {
+    if [ -d "$1" ]; then
+        umount "$1" || :
+        rmdir "$1"
+    fi
+}
+
 function cleanup() {
-    udisks_unmount "$DEVICE_IMAGES"
-    if [ ! "$MBR" ]; then
-        udisks_unmount "$DEVICE_EFI"
-    fi
-}
-
-function udisks_mount() {
-    udisksctl mount -b "$1" --no-user-interaction >&2
-    MOUNT_POINT=$(udisksctl info -b "$1" | awk '/MountPoints:/ { print $2 }')
-    if [ ! -d "$MOUNT_POINT" ]; then
-        echo "Failed to mount $1" >&2
-        exit 1
-    fi
-    echo "$MOUNT_POINT"
-}
-
-function udisks_unmount() {
-    udisksctl unmount -b "$1" --no-user-interaction >&2
+    cleanup_mountpoint "$ISO_MOUNTPOINT"
+    cleanup_mountpoint "$ESP_MOUNTPOINT"
+    cleanup_mountpoint "$EOSLIVE_MOUNTPOINT"
+    [ -d "$MOUNTS" ] && rmdir "$MOUNTS"
 }
 
 function find_by_type() {
@@ -435,25 +432,31 @@ EFI_PARTITIONS
     fi
 fi
 
-# Give udisks a chance to notice the new partitions
+# Give udev a chance to notice the new partitions
 udevadm settle
+
+# Below here we start mounting stuff, so register a cleanup function
+trap cleanup EXIT
 
 if [ ! "$MBR" ]; then
     mkfs.vfat -n efi "${DEVICE_EFI}"
     partprobe "$OUTPUT"
     udevadm settle
-    DIR_EFI=$(udisks_mount "$DEVICE_EFI")
+    mkdir -p "$ESP_MOUNTPOINT"
+    mount "$DEVICE_EFI" "$ESP_MOUNTPOINT"
+    DIR_EFI="$ESP_MOUNTPOINT"
 fi
 
 $MKFS_IMAGES $MKFS_ARGS eoslive "${DEVICE_IMAGES}"
 partprobe "$OUTPUT"
 udevadm settle
-DIR_IMAGES=$(udisks_mount "$DEVICE_IMAGES")
+mkdir -p "$EOSLIVE_MOUNTPOINT"
+mount "$DEVICE_IMAGES" "$EOSLIVE_MOUNTPOINT"
 
 echo
 echo "Copying boot files"
 
-DIR_IMAGES_ENDLESS="${DIR_IMAGES}/endless"
+DIR_IMAGES_ENDLESS="$EOSLIVE_MOUNTPOINT/endless"
 mkdir "$DIR_IMAGES_ENDLESS"
 unzip -q -d "${DIR_IMAGES_ENDLESS}" "${BOOT_ZIP}" "grub/*"
 
@@ -468,16 +471,16 @@ if [ ! "$WRITABLE" ]; then
 
     for EXTRA_DATA_PATH in "${EXTRA_DATA_PATHS[@]}"; do
         echo "Copying '$EXTRA_DATA_PATH'"
-        cp -r "$EXTRA_DATA_PATH" "$DIR_IMAGES/"
+        cp -r "$EXTRA_DATA_PATH" "$EOSLIVE_MOUNTPOINT/"
     done
 fi
 
 if [ ! "$WRITABLE" ] || [ "$WINDOWS_TOOL_PROVIDED" ]; then
     echo "Copying Windows-specific files"
 
-    cp "$WINDOWS_TOOL" "$DIR_IMAGES/"
+    cp "$WINDOWS_TOOL" "$EOSLIVE_MOUNTPOINT/"
     WINDOWS_TOOL_BASENAME="$(basename "$WINDOWS_TOOL")"
-    sed 's/$/\r/' <<AUTORUN_INF | iconv -f utf-8 -t utf-16 > "${DIR_IMAGES}/autorun.inf"
+    sed 's/$/\r/' <<AUTORUN_INF | iconv -f utf-8 -t utf-16 > "$EOSLIVE_MOUNTPOINT/autorun.inf"
 [AutoRun]
 label=${LABEL}
 icon=${WINDOWS_TOOL_BASENAME}
@@ -498,8 +501,6 @@ if [ "$ISO" ]; then
     cp "$ISO_MOUNTPOINT/endless/endless.squash" \
        "$ISO_MOUNTPOINT/endless/${OS_IMAGE_UNCOMPRESSED_BASENAME%.img}.squash.asc" \
        "$DIR_IMAGES_ENDLESS"
-    umount "$ISO_MOUNTPOINT"
-    rmdir "$ISO_MOUNTPOINT"
 else
     "$EOS_WRITE_IMAGE" "$OS_IMAGE" "-" > "${DIR_IMAGES_ENDLESS}/endless.img"
 fi
@@ -511,7 +512,6 @@ if [ "$EXPAND" ]; then
     if [ -n "$SIZE" ]; then
         if [ "$SIZE" -lt "$IMAGE_BYTES" ]; then
             echo "Cannot expand the image to $SIZE bytes, minimum size is $IMAGE_BYTES bytes" >&2
-            cleanup
             exit 1
         fi
 
@@ -520,7 +520,6 @@ if [ "$EXPAND" ]; then
 
         if [ "$EXTRA_BYTES" -gt "$FREE_SPACE_BYTES" ]; then
             echo "Cannot expand the image to $SIZE bytes, only $FREE_SPACE_BYTES bytes available" >&2
-            cleanup
             exit 1
         fi
     else

--- a/eos-tech-support/eos-write-live-image
+++ b/eos-tech-support/eos-write-live-image
@@ -480,7 +480,7 @@ echo "Copying image files"
 if [ "$ISO" ]; then
     # Loop-mount the ISO and copy the endless.squash and  directory
     mkdir -p "$ISO_MOUNTPOINT"
-    mount -o loop "$OS_IMAGE" "$ISO_MOUNTPOINT"
+    mount -o ro,loop "$OS_IMAGE" "$ISO_MOUNTPOINT"
     cp "$ISO_MOUNTPOINT/endless/endless.squash" \
        "$ISO_MOUNTPOINT/endless/${OS_IMAGE_UNCOMPRESSED_BASENAME%.img}.squash.asc" \
        "$DIR_IMAGES_ENDLESS"

--- a/eos-tech-support/eos-write-live-image
+++ b/eos-tech-support/eos-write-live-image
@@ -254,6 +254,9 @@ fi
 declare -A dependencies
 dependencies=(
     [dd]='coreutils'
+    [mkfs.vfat]='dosfstools'
+    [partprobe]='parted'
+    [sfdisk]='fdisk'
     [unzip]='unzip'
     [xzcat]='xz-utils'
     [zcat]='gzip'

--- a/eos-tech-support/eos-write-live-image
+++ b/eos-tech-support/eos-write-live-image
@@ -284,11 +284,6 @@ for command in "${!dependencies[@]}"; do
     fi
 done
 
-if [ -f "$OS_IMAGE" ] && \
-   [ "$(file --brief --mime-type "$OS_IMAGE")" = "application/x-iso9660-image" ]; then
-    ISO=true
-fi
-
 if [ -z "$FETCH_LATEST" ]; then
     if [ -z "$WINDOWS_TOOL" ] || [ -z "$OS_IMAGE" ]; then
         echo "--os-image and --windows-tool are required if --latest is not specified" >&2
@@ -363,11 +358,12 @@ fi
 
 check_exists "$OS_IMAGE" "image"
 
-# If image does not have a .gz, .xz or .iso suffix, assume it is the
-# uncompressed .img
-if [ "$ISO" ]; then
+if [[ "$OS_IMAGE" == *.iso ]]; then
+    ISO=true
     OS_IMAGE_UNCOMPRESSED="${OS_IMAGE%.iso}.img"
 else
+    # If image does not have a .gz, .xz or .iso suffix, assume it is the
+    # uncompressed .img
     OS_IMAGE_UNCOMPRESSED="${OS_IMAGE%.?z}"
 fi
 OS_IMAGE_UNCOMPRESSED_BASENAME="$(basename "${OS_IMAGE_UNCOMPRESSED}")"


### PR DESCRIPTION
This is another attempt at https://github.com/endlessm/eos-meta/pull/637, with an additional change to reverse the partition order to avoid triggering the undesired behaviour in eos-boot-helper.

It is on top of #644 to avoid conflicts.

Once again it doesn't work, for unknown reasons.

https://phabricator.endlessm.com/T30692