### PR TITLE
eos-core-depends: Replace gvfs-bin with libglib2.0-bin

### DIFF
--- a/eos-core-depends
+++ b/eos-core-depends
@@ -134,7 +134,6 @@ gnome-user-share
 gsfonts
 gstreamer1.0-gl
 gvfs-backends
-gvfs-bin
 gvfs-fuse
 hplip
 htop
@@ -159,6 +158,7 @@ imagescan-driver
 libblockdev-crypto2
 # Needed for image thumbnailer
 libgdk-pixbuf2.0-bin
+libglib2.0-bin
 libgpg-error-l10n
 libgphoto2-l10n
 # Assuming needed for iPod support


### PR DESCRIPTION
gvfs-bin has been removed in favour of libglib2.0-bin. The latter
contains different tools (the `gio` tool rather than `gvfs-copy` and
`gvfs-rename` etc.) but they are at least maintained.

Signed-off-by: Philip Withnall <pwithnall@endlessos.org>

https://phabricator.endlessm.com/T30813