### PR TITLE
eos-dev-suggests: Drop gnome-tweak-tool

### DIFF
--- a/eos-dev-suggests
+++ b/eos-dev-suggests
@@ -41,7 +41,6 @@ d-feet
 eos-dev-kernel
 evemu-tools
 gcovr
-gnome-tweak-tool
 gparted
 jq
 kbd


### PR DESCRIPTION
Our current version is very old and doesn't work with latest GNOME and is causing some build failures on jenkins PR jobs.

The package got renamed to gnome-tweaks and latest from debian is 3.34.0. Let's remove it for now to fix the jenkins PR jobs and we can re-add later if needed.