### PR TITLE
eos-dev-suggests: Drop d-feet

### DIFF
--- a/eos-dev-suggests
+++ b/eos-dev-suggests
@@ -37,7 +37,6 @@ arcanist
 at
 awscli
 codecgraph
-d-feet
 eos-dev-kernel
 evemu-tools
 gcovr


### PR DESCRIPTION
This is causing a build failure on jenkins PR jobs and the app is available on flathub so let's drop it here.