### PR TITLE
core: Add libfsapfs-utils package

### DIFF
--- a/eos-core-depends
+++ b/eos-core-depends
@@ -156,6 +156,8 @@ imagemagick
 # Needed to support some Epson scanners
 imagescan-driver
 libblockdev-crypto2
+# Needed to unpack Apple DMG files for the Endless Key project
+libfsapfs-utils
 # Needed for image thumbnailer
 libgdk-pixbuf2.0-bin
 libglib2.0-bin


### PR DESCRIPTION
This is to be able to access Apple DMG packages, necessary to create the
Endless Key image with Apple software.

https://phabricator.endlessm.com/T30829