### PR TITLE
eos-core-depends: Add gnome-remote-desktop

### DIFF
--- a/eos-core-depends
+++ b/eos-core-depends
@@ -122,6 +122,7 @@ gnome-keyring-pkcs11
 gnome-logs
 gnome-online-accounts
 gnome-orca
+gnome-remote-desktop
 gnome-screenshot
 gnome-shell-extension-appindicator
 gnome-software


### PR DESCRIPTION
This is needed for the GNOME screen sharing support.

https://phabricator.endlessm.com/T30882