### PR TITLE
eos-core: Install git

### DIFF
--- a/eos-core-depends
+++ b/eos-core-depends
@@ -107,6 +107,7 @@ fprintd
 fuse-overlayfs
 gdb
 gedit
+git
 # For showing the keyboard layout from the control center
 gkbd-capplet
 gnome-bluetooth


### PR DESCRIPTION
Previously, git was installed only as a dependency of flapjack, which we
removed in 3adf120525d0e538b98e1dca0b9bf4ca90046001.

I believe it is too useful to exclude. However, it does add 38 MB to
the ostree.

https://phabricator.endlessm.com/T30935