### PR TITLE
eos-core: Drop eos-install-app-helper

### DIFF
--- a/eos-core-depends
+++ b/eos-core-depends
@@ -56,7 +56,6 @@ eos-flatpak-autoinstall
 eos-gates
 eos-google-chrome-helper [amd64]
 eos-hack-extension
-eos-install-app-helper [amd64]
 eos-installer
 eos-kalite-system-helper
 eos-kalite-tools


### PR DESCRIPTION
We are no longer shipping "Get app" icons in the desktop and eos-install-app-helper is no longer used/needed.

https://phabricator.endlessm.com/T30820