### PR TITLE
eos-write-metrics-collector-usb: Fix empty PATH after partprobe

### DIFF
--- a/eos-tech-support/eos-write-metrics-collector-usb
+++ b/eos-tech-support/eos-write-metrics-collector-usb
@@ -71,6 +71,7 @@ udevadm settle
 # to the disk, which neither 'sfdisk --wipe' nor 'dd if=/dev/zero' are able to
 # avoid. Let's allow it to fail without halting the program.
 partprobe "$TARGET_DISK" || true
+udevadm settle
 
 PART="$(lsblk --noheadings --output PATH $TARGET_DISK | sed '1d')"
 echo "== Formatting $PART =="


### PR DESCRIPTION
The `lsblk` command after partprobe will return empty PATH for the
target disk. Add a udevadm settle to make sure the OS already has
the partition table change.

https://phabricator.endlessm.com/T30781