### PR TITLE
eos-core: Add alsa-topology-conf and alsa-ucm-conf

### DIFF
--- a/eos-core-depends
+++ b/eos-core-depends
@@ -14,6 +14,8 @@ hunspell-pt-br
 hunspell-th
 hunspell-vi
 
+alsa-topology-conf
+alsa-ucm-conf
 alsa-utils
 apt
 apt-transport-https


### PR DESCRIPTION
The alsa-lib's configuration files have been moved to alsa-ucm-conf and
alsa-topology-conf since commit 1f37ba2a2b1c ("ucm: remove configuration
files (moved to alsa-ucm-conf repository)") and cdc8aacbb57c ("topology:
remove configuration files (moved to alsa-topology-conf repository)").
So, we have to install them respectively.

https://phabricator.endlessm.com/T31176