### PR TITLE
eos-stage-*: Use CDN for dev repo URLs

### DIFF
--- a/eos-tech-support/eos-stage-flatpak
+++ b/eos-tech-support/eos-stage-flatpak
@@ -70,7 +70,7 @@ if [ "$STAGE" == "dev" ] ; then
 	echo "Error: missing required PASSWORD for dev stage" >&2
 	exit 1
     fi
-    base_url="https://endless:${PASSWORD}@origin.ostree.endlessm.com/staging/dev"
+    base_url="https://endless:${PASSWORD}@ostree.endlessm.com/staging/dev"
 elif [ "$STAGE" == "demo" ] ; then
     base_url="https://ostree.endlessm.com/staging/demo"
 elif [ "$STAGE" == "prod" ] ; then

--- a/eos-tech-support/eos-stage-ostree
+++ b/eos-tech-support/eos-stage-ostree
@@ -59,7 +59,7 @@ if [ "$STAGE" == "dev" ] ; then
 	echo "Error: missing required PASSWORD for dev stage" >&2
 	exit 1
     fi
-    base_url="https://endless:${PASSWORD}@origin.ostree.endlessm.com/staging/dev"
+    base_url="https://endless:${PASSWORD}@ostree.endlessm.com/staging/dev"
     new_collection_id="com.endlessm.Dev.Os"
     # dev stages stay on the major version (e.g., eos3.2)
     series="eos${major_version}"


### PR DESCRIPTION
With our shiny new Fastly CDN we can appropriately pass through HTTP
authentication to our origin server and don't need to access it
directly.

https://phabricator.endlessm.com/T31157