### PR TITLE
eos-stage-ostree: Remove password requirement

### DIFF
--- a/eos-tech-support/eos-convert-system-qa
+++ b/eos-tech-support/eos-convert-system-qa
@@ -79,21 +79,21 @@ fi
 
 # Change OSTree and Flatpak servers to staging.
 if $OSTREE || $APPS; then
-    # Get the HTTP password for the dev repos.
-    read -p "OSTree password: " OSTREE_PASSWORD
-    if [ -z "$OSTREE_PASSWORD" ]; then
-        echo "error: No password supplied" >&2
-        exit 1
-    fi
-
     # Change the Flatpak runtime and apps server URLs to the dev stage.
     if $APPS; then
+        # Get the HTTP password for the dev repos.
+        read -p "OSTree password: " OSTREE_PASSWORD
+        if [ -z "$OSTREE_PASSWORD" ]; then
+            echo "error: No password supplied" >&2
+            exit 1
+        fi
+
         eos-stage-flatpak dev "${OSTREE_PASSWORD}"
     fi
 
     # Change OSTree server URL to the dev stage.
     if $OSTREE; then
-        eos-stage-ostree dev "${OSTREE_PASSWORD}"
+        eos-stage-ostree dev
     fi
 fi
 

--- a/eos-tech-support/eos-stage-ostree
+++ b/eos-tech-support/eos-stage-ostree
@@ -3,23 +3,22 @@
 function usage {
     cat <<EOF
 Usage:
-    $0 STAGE [PASSWORD]
+    $0 STAGE
 Arguments:
     STAGE     One of the following:
-                - dev: development staging (requires password)
-                       (note that the dev stage does not automatically
-                       update to the next major release series)
+                - dev: development staging (note that the dev stage does
+                       not automatically update to the next major release
+                       series)
                 - demo: beta testing in advance of production releases
                 - prod: full production releases for general availability
-    PASSWORD  Development password (for staging branch only)
 EOF
 }
 
-if [ $# -lt 1 ] || [ $# -gt 2 ] ; then
+if [ $# -ne 1 ] ; then
     if [ $# -lt 1 ] ; then
         echo "Error: missing STAGE argument" >&2
     else
-        echo "Error: extra arguments after STAGE PASSWORD" >&2
+        echo "Error: extra arguments after STAGE" >&2
     fi
     echo >&2
     usage >&2
@@ -27,11 +26,6 @@ if [ $# -lt 1 ] || [ $# -gt 2 ] ; then
 fi
 
 STAGE="$1"
-
-PASSWORD=
-if [ $# -ge 2 ] ; then
-    PASSWORD="$2"
-fi
 
 if [ $EUID != 0 ] ; then
     echo "Program requires superuser privileges" >&2
@@ -55,11 +49,7 @@ case "$major_version" in
 esac
 
 if [ "$STAGE" == "dev" ] ; then
-    if [ -z "$PASSWORD" ] ; then
-	echo "Error: missing required PASSWORD for dev stage" >&2
-	exit 1
-    fi
-    base_url="https://endless:${PASSWORD}@ostree.endlessm.com/staging/dev"
+    base_url="https://ostree.endlessm.com/staging/dev"
     new_collection_id="com.endlessm.Dev.Os"
     # dev stages stay on the major version (e.g., eos3.2)
     series="eos${major_version}"


### PR DESCRIPTION
The OS dev repos are now available without authentication, so there's no
longer any need to supply a password to embed in the remote URL.

https://phabricator.endlessm.com/T31288