### PR TITLE
Use podman from debian bullseye

### DIFF
--- a/eos-core-depends
+++ b/eos-core-depends
@@ -191,7 +191,6 @@ openssh-server
 # For flatpak-builder
 patch
 podman
-podman-docker
 # For modem support
 ppp
 printer-driver-all-enforce

--- a/eos-dev-suggests
+++ b/eos-dev-suggests
@@ -6,10 +6,6 @@
 # scripts have special provisions to consider anything listed here as a
 # required part of our distro.
 
-# Robert McQueen is prototyping these container-based development tools.
-# They will probably be added to the ostree once ready.
-toolbox
-
 # Robert McQueen is prototyping this for encrypted home directories.
 # It will probably be added to the ostree once ready.
 fscrypt

--- a/eos-toolbox-dev-depends
+++ b/eos-toolbox-dev-depends
@@ -53,7 +53,6 @@ patchutils
 pbuilder
 pycodestyle
 podman
-podman-docker
 procps
 python3
 quilt


### PR DESCRIPTION
This removes podman-docker which is not available on debian bullseye.

https://phabricator.endlessm.com/T31300