### PR TITLE
eos-core-depends: Ship both runc and crun OCI runtimes

### DIFF
--- a/eos-core-depends
+++ b/eos-core-depends
@@ -31,6 +31,8 @@ brasero-cdrkit
 cdrdao
 cheese
 cracklib-runtime
+# Runtime for podman containers
+crun
 cups
 cups-browsed
 cups-pk-helper
@@ -199,6 +201,9 @@ python3-pip
 python3-venv
 rhythmbox (>= 2.99.1)
 rhythmbox-plugins
+# Legacy container runtime, needed to delete containers from
+# older versions of podman that used it as default (T31300)
+runc
 rtkit
 shotwell
 simple-scan


### PR DESCRIPTION
`podman` depends on `runc | crun` which gets `runc` installed automatically as a dependency.
The problem is `runc` requires cgroupsv1, which is disabled on latest master, while `crun` works fine with cgroupsv2.

We should ship both to:
- allow users to delete existing containers created with `runc` as the runtime (any container created pre-4.0)
- allow users to create new containers with cgroupsv1 disabled (and cgroupsv2 enabled), which only works with `crun`

Note users still won't be able to use containers created with `runc` but they should be able to at least remove them with `podman` cmdline.

https://phabricator.endlessm.com/T31300