### PR TITLE
Use the new toolbox version (Go version)

### DIFF
--- a/eos-core-depends
+++ b/eos-core-depends
@@ -189,6 +189,7 @@ openssh-server
 # For flatpak-builder
 patch
 podman
+podman-toolbox
 # For modem support
 ppp
 printer-driver-all-enforce
@@ -212,7 +213,6 @@ system-config-printer-gnome
 system-config-printer-udev
 systemd-coredump
 thermald [amd64]
-toolbox
 tracker
 tracker-miner-fs
 ttf-ancient-fonts


### PR DESCRIPTION
The new package is named podman-toolbox instead of toolbox.

https://phabricator.endlessm.com/T31300