### PR TITLE
eos-core: Move printer drivers dependencies

### DIFF
--- a/eos-core-amd64-depends
+++ b/eos-core-amd64-depends
@@ -1,1 +1,4 @@
 eos-core
+printer-driver-cnijfilter
+printer-driver-cnijfilter2
+printer-driver-escp

--- a/eos-core-depends
+++ b/eos-core-depends
@@ -195,9 +195,6 @@ podman-toolbox
 # For modem support
 ppp
 printer-driver-all-enforce
-printer-driver-cnijfilter
-printer-driver-cnijfilter2
-printer-driver-escp
 python3-pip
 python3-venv
 rhythmbox (>= 2.99.1)


### PR DESCRIPTION
Some printer drivers like printer-driver-cnijfilter,
printer-driver-cnijfilter2 and printer-driver-escp are only available on
amd64 architecture. So, move them from general dependency to amd64 only.
Otherwise, arm64 OSTree will build failed on the dependencies.

Fixes: 823f129b350d ("eos-core: Depend on extra printer drivers")

https://phabricator.endlessm.com/T31261