### PR TITLE
eos-core-depends: Drop gnome-getting-started-docs

### DIFF
--- a/eos-core-depends
+++ b/eos-core-depends
@@ -119,7 +119,6 @@ gnome-contacts
 gnome-control-center
 gnome-disk-utility
 gnome-font-viewer
-gnome-getting-started-docs
 gnome-initial-setup
 gnome-keyring-pkcs11
 gnome-logs


### PR DESCRIPTION
All the documentation in this guide has hand-drawn illustrations and animations which do not apply to Endless OS.

Let's remove this package from the ostree which should also take care of removing the reference to it from the landing page of Yelp.

https://phabricator.endlessm.com/T31392