### PR TITLE
eos-core: Drop eos-codecs-manager

### DIFF
--- a/eos-core-depends
+++ b/eos-core-depends
@@ -51,7 +51,6 @@ eos-acknowledgements
 eos-adblock-plus-extensions
 eos-b43fw-install
 eos-browser-tools
-eos-codecs-manager
 eos-desktop-extension
 eos-event-recorder-daemon
 eos-flatpak-autoinstall


### PR DESCRIPTION
We have long since stopped offering the codec key for purchase & download, and have decided to drop this from the OS since the need for non-free codecs is now (mostly) handled by Flatpak.

Depends on https://github.com/endlessm/eos-image-builder/pull/971 and https://github.com/endlessm/eos-ostree-builder/pull/162.

https://phabricator.endlessm.com/T31520