### PR TITLE
eos-core: Drop cheese

### DIFF
--- a/eos-core-depends
+++ b/eos-core-depends
@@ -29,7 +29,6 @@ bolt
 brasero
 brasero-cdrkit
 cdrdao
-cheese
 cracklib-runtime
 # Runtime for podman containers
 crun


### PR DESCRIPTION
We are going to direct users to cheese's flatpak from flathub.

Some apps still use libcheese, but those should depend directly on it if so.

https://phabricator.endlessm.com/T31429