### PR TITLE
base-depends: Replace highcontrast-icon-theme with gnome-accessibility-themes

### DIFF
--- a/base-depends
+++ b/base-depends
@@ -7,12 +7,12 @@ fonts-freefont-ttf
 fonts-lato
 fonts-liberation
 fonts-wqy-microhei
+gnome-accessibility-themes
 gstreamer1.0-libav
 gstreamer1.0-plugins-good
 gstreamer1.0-pulseaudio
 gstreamer1.0-tools
 gstreamer1.0-vaapi
-highcontrast-icon-theme
 ibus-gtk3
 libcanberra-gtk3-module
 libcanberra-pulse


### PR DESCRIPTION
We used to split highcontrast-icon-theme out of gnome-accessibility-themes to avoid a GTK2 dependency, but the latest package from bullseye (which we will be using) already dropped the GTK2 dependency.

https://phabricator.endlessm.com/T31428