### PR TITLE
eos-core: Add mmdebstrap for running eos-image-builder

### DIFF
--- a/eos-core-depends
+++ b/eos-core-depends
@@ -178,6 +178,8 @@ libpam-gnome-keyring
 libsasl2-modules
 # Parental controls
 malcontent-control
+# For running the image builder from Endless
+mmdebstrap
 modemmanager
 nautilus
 nautilus-extension-brasero


### PR DESCRIPTION
The only other requirements for the image builder are python3 and gpg,
which are already included. I believe this should only add 87kB to the
OS as mmdebstrap dependencies are apt, python3 and perl, which are
already in the OS.

https://phabricator.endlessm.com/T31702