### PR TITLE
eos-core: Install tmate

### DIFF
--- a/eos-core-depends
+++ b/eos-core-depends
@@ -214,6 +214,7 @@ system-config-printer-gnome
 system-config-printer-udev
 systemd-coredump
 thermald [amd64]
+tmate
 tracker
 tracker-miner-fs
 ttf-ancient-fonts


### PR DESCRIPTION
This tool is very useful for remote technical support. Having it
pre-installed in the OS simplifies the instructions we need to give to
the user who needs support.

https://phabricator.endlessm.com/T31863
