### PR TITLE
eos-core-amd64: Drop printer-drivers-cnijfilter{2} & printers-driver-escp

### DIFF
--- a/eos-core-amd64-depends
+++ b/eos-core-amd64-depends
@@ -1,4 +1,1 @@
 eos-core
-printer-driver-cnijfilter
-printer-driver-cnijfilter2
-printer-driver-escp


### PR DESCRIPTION
EOS is going to use driverless printers, so remove them.

https://phabricator.endlessm.com/T31859