### PR TITLE
eos-core: Replace hplip with printer-driver-hpcups

### DIFF
--- a/eos-core-depends
+++ b/eos-core-depends
@@ -137,7 +137,6 @@ gsfonts
 gstreamer1.0-gl
 gvfs-backends
 gvfs-fuse
-hplip
 htop
 ibus-anthy
 ibus-avro


### PR DESCRIPTION
Follow Debian to strip all of the non-free hooks. Also do not ship hplip
at all, just the hpcups filters.

https://phabricator.endlessm.com/T31860