### PR TITLE
Explicitly depend on wget

### DIFF
--- a/eos-core-depends
+++ b/eos-core-depends
@@ -228,6 +228,7 @@ vainfo
 vinagre
 vino
 whiptail
+wget
 xinput
 # Assuming useful for Orca screen reader
 xbrlapi


### PR DESCRIPTION
This used to be pulled in as a (transitive) dependency of something
else. (I'm not actually sure what.)

I think it is reasonable to include at least one of 'curl' and 'wget'.
Since we have historically shipped 'wget', and I found recent posts on
the forum assuming it was present, let's keep it.

https://phabricator.endlessm.com/T31889
