### PR TITLE
eos-core: Replace system-config-printer-gnome with system-config-printer-common

### DIFF
--- a/eos-core-depends
+++ b/eos-core-depends
@@ -210,7 +210,7 @@ smbclient
 sound-icons
 speech-dispatcher-espeak-ng
 strace
-system-config-printer-gnome
+system-config-printer-common
 system-config-printer-udev
 systemd-coredump
 thermald [amd64]


### PR DESCRIPTION
EOS is going to install Debian's printer packages directly. There is no
more EOS downstream maintained system-config-printer to provide the
system-config-printer-gnome.
Besides, the gnome-control-center already provide the "Printers" UI to
manage the printers. So, EOS only needs the system-config-printer-common
as the backend.

https://phabricator.endlessm.com/T31858