### PR TITLE
Remove vinagre from eos-core

### DIFF
--- a/eos-core-depends
+++ b/eos-core-depends
@@ -224,7 +224,6 @@ unrar
 # For data transfer with iOS devices
 usbmuxd
 vainfo
-vinagre
 vino
 whiptail
 wget


### PR DESCRIPTION
This app is not widely used on Endless OS. It is unmaintained upstream,
and there are more modern alternatives covering the same (or more)
functionality, such as Connections and Remmina, available on Flathub.

https://phabricator.endlessm.com/T31658
