### PR TITLE
eos-core: remove vino

### DIFF
--- a/eos-core-depends
+++ b/eos-core-depends
@@ -222,7 +222,6 @@ unrar
 # For data transfer with iOS devices
 usbmuxd
 vainfo
-vino
 whiptail
 wget
 xinput


### PR DESCRIPTION
This has been obsolete since we started shipping gnome-remote-desktop in
14c07884f0d0e4cc72b929fea536227552a20194.

https://phabricator.endlessm.com/T31990
