### PR TITLE
os: Drop ntp

### DIFF
--- a/os-depends
+++ b/os-depends
@@ -92,7 +92,6 @@ nvidia-driver-bin [amd64]
 nvidia-kernel-drivers [amd64]
 nvidia-kernel-drivers-blob-signed [amd64]
 nvidia-modprobe [amd64]
-ntp
 open-vm-tools-desktop [amd64]
 openssh-client
 ostree


### PR DESCRIPTION
We are switching from ntp to the simpler systemd-timesyncd.

https://phabricator.endlessm.com/T16376