### PR TITLE
core: Change malcontent-control dependency to malcontent-gui

### DIFF
--- a/eos-core-depends
+++ b/eos-core-depends
@@ -174,7 +174,7 @@ libpam-gnome-keyring
 # Assumed useful for apps that use libsasl2
 libsasl2-modules
 # Parental controls
-malcontent-control
+malcontent-gui
 # For running the image builder from Endless
 mmdebstrap
 modemmanager

--- a/eos-dev-suggests
+++ b/eos-dev-suggests
@@ -37,5 +37,5 @@ python3-boto
 python3-boto3
 qemu-utils
 resolvconf
-shim
+shim-unsigned
 x11-apps


### PR DESCRIPTION
We're adopting debian's malcontent packaging, and that uses the
malcontent-gui package name to provide the `malcontent-control` program.

https://phabricator.endlessm.com/T30746