### PR TITLE
dev: Suggest shim-unsigned instead of shim

### DIFF
--- a/eos-dev-suggests
+++ b/eos-dev-suggests
@@ -37,5 +37,5 @@ python3-boto
 python3-boto3
 qemu-utils
 resolvconf
-shim
+shim-unsigned
 x11-apps


### PR DESCRIPTION
Newer debian packaging for shim puts the unsigned components in the
shim-unsigned package, which is marked to replace shim. This fixes the
check-deps test.