### PR TITLE
os-depends: Drop fake-hwclock

### DIFF
--- a/os-depends
+++ b/os-depends
@@ -28,7 +28,6 @@ eos-updater
 eos-version-number
 exfat-fuse
 exfat-utils
-fake-hwclock
 fdisk
 file
 fonts-dejavu


### PR DESCRIPTION
Now that systemd-timesyncd acquired the same functionality from
fake-hwclock and that we are installing and enabling systemd-timesyncd
instead of ntpd, we can drop fake-hwclock and rely on systemd-timesyncd
to provide a monotonic clock.

https://phabricator.endlessm.com/T32428