### PR TITLE
Remove all references to armhf

### DIFF
--- a/base-depends
+++ b/base-depends
@@ -17,13 +17,11 @@ ibus-gtk3
 libcanberra-gtk3-module
 libcanberra-pulse
 libcaribou-gtk3-module
-# Mali used on arm
-libegl-mesa0 [!armhf]
-libegl1 [!armhf]
-# Mali used on arm
-libgles2 [!armhf]
+libegl-mesa0
+libegl1
+libgles2
 libglib2.0-data
-libglu1-mesa [!armhf]
+libglu1-mesa
 libgl1-mesa-dri
 libgl1-nvidia-glvnd-glx [amd64]
 libglx-mesa0

--- a/debian/control
+++ b/debian/control
@@ -129,15 +129,6 @@ Description: EndlessOS Kernel Team Development Tools
  .
  This set provides the platform specific package list for amd64.
 
-Package: eos-dev-kernel-armhf
-Architecture: armhf
-Depends: ${misc:Depends}, ${eos:Depends}
-Description: EndlessOS Kernel Team Development Tools
- This is a collection of development tools for the Kernel team that make
- development and debugging of EndlessOS easier and more efficient.
- .
- This set provides the platform specific package list for armhf.
-
 Package: eos-tech-support
 Architecture: all
 Depends: ${eos:Depends},

--- a/eos-dev-kernel-armhf-depends
+++ b/eos-dev-kernel-armhf-depends
@@ -1,1 +1,0 @@
-eos-dev-kernel

--- a/os-depends
+++ b/os-depends
@@ -116,8 +116,6 @@ sudo
 systemd-boot-signed [amd64]
 systemd-sysv
 systemd
-# ARM boot loader
-u-boot-tools [armhf]
 udev
 usb-modeswitch
 vim-tiny

--- a/os-ec100-depends
+++ b/os-ec100-depends
@@ -1,1 +1,0 @@
-xserver-xorg-video-armsoc

--- a/os-s905x-depends
+++ b/os-s905x-depends
@@ -1,1 +1,0 @@
-xserver-xorg-video-armsoc


### PR DESCRIPTION
We don't support this architecture anymore after the EOS 3.8 series.

https://phabricator.endlessm.com/T30303