### PR TITLE
eos-core: Drop htop

### DIFF
--- a/eos-core-depends
+++ b/eos-core-depends
@@ -140,7 +140,6 @@ gsfonts
 gstreamer1.0-gl
 gvfs-backends
 gvfs-fuse
-htop
 ibus-anthy
 ibus-avro
 ibus-cangjie


### PR DESCRIPTION
EOS aleady has GNOME System Monitor, so drop htop.

https://phabricator.endlessm.com/T31569