### PR TITLE
os-depends: Drop im-config

### DIFF
--- a/os-depends
+++ b/os-depends
@@ -53,8 +53,6 @@ grub-efi-amd64-image-signed [amd64 i386]
 grub-efi-ia32-image [amd64 i386]
 # Used for the initial hardware evaluation
 hdparm
-# Required for unknown reasons (see T19310)
-im-config
 intel-microcode [amd64]
 iproute2
 # NetworkManager uses this to avoid IP address conflicts


### PR DESCRIPTION
GNOME has its own UI for configuring input methods. Try to remove the
duplicated im-config package.

https://phabricator.endlessm.com/T32538