### PR TITLE
eos-stage-ostree: Remove branch handling

### DIFF
--- a/eos-tech-support/eos-stage-ostree
+++ b/eos-tech-support/eos-stage-ostree
@@ -32,27 +32,9 @@ if [ $EUID != 0 ] ; then
     exit 1
 fi
 
-# Get the OS product.major version to build the branch series from. By
-# default, the system updates from the product version (e.g., eos3).
-major_version=$(. /etc/os-release && echo $VERSION | cut -d. -f1-2)
-product_version=${major_version%%.*}
-series="eos${product_version}"
-
-# On 3.4+, eos3a is used as the series as the 3.3 to 3.4 transition
-# implemented a checkpoint on the eos3 branch.
-#
-# https://phabricator.endlessm.com/T21855
-case "$major_version" in
-    3.[4-9]|3.[1-9][0-9])
-        series=eos3a
-        ;;
-esac
-
 if [ "$STAGE" == "dev" ] ; then
     base_url="https://ostree.endlessm.com/staging/dev"
     new_collection_id="com.endlessm.Dev.Os"
-    # dev stages stay on the major version (e.g., eos3.2)
-    series="eos${major_version}"
     # Check for an update every time the updater runs
     interval_days=0
 elif [ "$STAGE" == "demo" ] ; then
@@ -70,14 +52,6 @@ else
     exit 1
 fi
 
-# Get the current refspec.
-refspec=$(ostree admin status | awk '/refspec:/{print $3}' | head -n1)
-branch=${refspec#*:}
-
-# Construct the new branch with the series depending on the stage.
-new_branch="${branch%/*}/${series}"
-echo "Using OSTree branch $new_branch"
-
 # Get the current URL and convert to the new stage.
 url=$(ostree config get 'remote "eos".url')
 repo=${url##*/}
@@ -92,16 +66,9 @@ echo "Killing eos-updater."
 systemctl stop eos-updater.service
 
 echo "Configuring OSTree for $STAGE stage."
-# HACK! HACK! HACK! ostree admin set-origin is horribly broken
-# as of ostree 2015.7. It won't change the url or use any --set
-# options for an existing remote. Instead, use the config
-# builtin to handle that. The correct set-origin command is left
-# in place in case this is ever fixed. Upstream bug at
-# https://bugzilla.gnome.org/show_bug.cgi?id=753373
+
+# Update the repo URL
 ostree config set 'remote "eos".url' "$new_url"
-ostree config set 'remote "eos".branches' "${new_branch};"
-ostree admin set-origin eos "$new_url" "$new_branch" \
-       --set=branches="${new_branch};"
 
 # Update the collection ID if it's set
 collection_id=$(ostree config get 'remote "eos".collection-id' 2>/dev/null || echo "")


### PR DESCRIPTION
Previously the development OS repo would not have reliable stable refs
because there might be multiple active branches publishing the stable
ref at the same time. For example, when `eos3.X` is branched but not yet
released, there are likely still builds for `eos3.X-1` happening and
both builds would be pushing to the `eos3a` stable branch ref. The same
goes for the new `latestN` branch ref.

Now the ostree builder configurations have been cleaned up so that only
one build at a time should be publishing a given stable or latest
branch. With that we can reliably use the same branch in any repo stage
and don't need to use heuristics to try to change it. `eos-stage-ostree`
is changed to simply update the repo URL and collection ID and leave the
branch alone. Anyone switching between OS refs is doing something fairly
advanced and can handle it outside of this script.

https://phabricator.endlessm.com/T32639