### PR TITLE
eos-core: Reintroduce cups-browsed for Flatpak applications

### DIFF
--- a/eos-core-depends
+++ b/eos-core-depends
@@ -35,6 +35,7 @@ cracklib-runtime
 # Runtime for podman containers
 crun
 cups
+cups-browsed
 cups-pk-helper
 debconf-i18n
 # For NetworkManager connection sharing and podman DNS resolution


### PR DESCRIPTION
Most of Flatpak's applications cannot get the CUPS temporary queue
printer curently.

It may be caused by linked old GTK library, no Avahi support or other
flatpak/sandbox limitation.

We may fix some key applications, but it is hard to fix all of them in
time. So, that is why cups-browsed is reintroduced again.

https://phabricator.endlessm.com/T32645