### PR TITLE
eos-core: Move Shotwell to flatpak

### DIFF
--- a/eos-core-depends
+++ b/eos-core-depends
@@ -206,7 +206,6 @@ rfkill
 runc
 rtkit
 sane-airscan
-shotwell
 simple-scan
 # For rootless podman
 slirp4netns

--- a/eos-tech-support/eos-user-stress-test
+++ b/eos-tech-support/eos-user-stress-test
@@ -114,7 +114,7 @@ case $command in
         ;;
     heavy)
         check_deps_heavy
-        command_launch shotwell
+        command_launch flatpak run org.gnome.Shotwell
         command_launch flatpak run org.gimp.Gimp ${DATA_FILES}/coffee-2mp.jpg
         command_launch loimpress --norestore \
             ${DATA_FILES}/example-presentation.odp


### PR DESCRIPTION
Drop Shotwell from the default OSTree in favour of installing it from
flatpak instead.

Signed-off-by: Philip Withnall <pwithnall@endlessos.org>

https://phabricator.endlessm.com/T31431