### PR TITLE
Remove exfat-fuse from OS

### DIFF
--- a/os-depends
+++ b/os-depends
@@ -26,7 +26,6 @@ eos-plymouth-theme
 eos-tech-support
 eos-updater
 eos-version-number
-exfat-fuse
 exfat-utils
 fdisk
 file


### PR DESCRIPTION
This package is unnecessary and unused since we now have a kernel
version with native support for exFAT filesystems.

https://phabricator.endlessm.com/T32749
