### PR TITLE
eos-core: Depend on xdg-desktop-portal-gnome

### DIFF
--- a/eos-core-depends
+++ b/eos-core-depends
@@ -227,8 +227,8 @@ wget
 xinput
 # Assuming useful for Orca screen reader
 xbrlapi
-xdg-desktop-portal
-xdg-desktop-portal-gtk
+# Allows Flatpak apps to access various session & system services in a managed fashion.
+xdg-desktop-portal-gnome
 yelp
 # Used by mutter for showing dialogs
 zenity


### PR DESCRIPTION
This module is a new companion to xdg-desktop-portal-gtk, maintained as
part of GNOME. It contains GNOME-specific interfaces that used to live
in -gtk prior to its 1.12 series.

The -gnome package depends on the other two so we only need to list this
one.

https://phabricator.endlessm.com/T32965
