### PR TITLE
Remove flatpak-builder

### DIFF
--- a/eos-core-depends
+++ b/eos-core-depends
@@ -77,7 +77,6 @@ evolution-plugin-pstimport
 evolution-plugins
 file-roller
 flatpak
-flatpak-builder
 fonts-arabeyes
 fonts-crosextra-caladea
 fonts-crosextra-carlito


### PR DESCRIPTION
We take flatpak-builder directly from Debian, but maintain our own
Flatpak. Due to a security issue, flatpak-builder now has a versioned
dependency on a newer version of Flatpak than we have in the distro.

Remove flatpak-builder. We can readd it once we have updated Flatpak. In
the meantime the org.flatpak.Builder package from Flathub can be used
instead.

https://phabricator.endlessm.com/T32961
