### PR TITLE
core: Update gnome-user-docs package name

### DIFF
--- a/eos-core-depends
+++ b/eos-core-depends
@@ -130,7 +130,7 @@ gnome-software-plugin-flatpak
 gnome-sushi
 gnome-system-monitor
 gnome-terminal
-gnome-user-guide
+gnome-user-docs
 gnome-user-share
 # For podman DNS resolution between containers in a network
 golang-github-containernetworking-plugin-dnsname


### PR DESCRIPTION
gnome-user-guide is an empty transitional package which just depends on
gnome-user-docs.

https://phabricator.endlessm.com/T32935
