### PR TITLE
base-depends: Switch from locales to locales-all

### DIFF
--- a/base-depends
+++ b/base-depends
@@ -27,7 +27,7 @@ libgl1-nvidia-glvnd-glx [amd64]
 libglx-mesa0
 libnss-altfiles
 libnss-myhostname
-locales
+locales-all
 lzma
 mawk
 netbase


### PR DESCRIPTION
Currently we ship the components of available locales via the `locales`
package and then compile them in the OSTree builder using `locale-gen`.
However, we compile all available locales so that the OS has the entire
set available. This takes about 20 minutes per OSTree build.

Instead, we can install the `locales-all` package, which has all the
locales pre-compiled into a package. At that point we no longer need the
`locales` package since there are no remaining locales to compile from
source components.

https://phabricator.endlessm.com/T32970