### PR TITLE
core: install orca, not gnome-orca

### DIFF
--- a/base-depends
+++ b/base-depends
@@ -10,7 +10,6 @@ fonts-wqy-microhei
 gnome-accessibility-themes
 gstreamer1.0-libav
 gstreamer1.0-plugins-good
-gstreamer1.0-pulseaudio
 gstreamer1.0-tools
 gstreamer1.0-vaapi
 ibus-gtk3

--- a/eos-core-depends
+++ b/eos-core-depends
@@ -18,7 +18,6 @@ alsa-topology-conf
 alsa-ucm-conf
 alsa-utils
 apt
-apt-transport-https
 apt-utils
 avahi-daemon
 # For field debugging

--- a/eos-core-depends
+++ b/eos-core-depends
@@ -77,6 +77,7 @@ evolution-plugins
 file-roller
 flatpak
 flatpak-builder
+fonts-ancient-scripts
 fonts-arabeyes
 fonts-crosextra-caladea
 fonts-crosextra-carlito
@@ -99,6 +100,7 @@ fonts-sil-andika
 fonts-sil-gentium
 fonts-sil-gentium-basic
 fonts-sil-padauk
+fonts-symbola
 fonts-thai-tlwg
 fonts-uralic
 foomatic-db-compressed-ppds
@@ -218,7 +220,6 @@ thermald [amd64]
 tmate
 tracker
 tracker-miner-fs
-ttf-ancient-fonts
 # For rootless podman
 uidmap
 unrar

--- a/eos-core-depends
+++ b/eos-core-depends
@@ -121,7 +121,6 @@ gnome-keyring-pkcs11
 # So GNOME Shell can provide default names when creating folders
 gnome-menus
 gnome-online-accounts
-gnome-orca
 gnome-remote-desktop
 gnome-screenshot
 gnome-shell-extension-appindicator
@@ -190,6 +189,7 @@ network-manager-openvpn-gnome
 network-manager-vpnc-gnome
 openprinting-ppds
 openssh-server
+orca
 # For flatpak-builder
 patch
 podman


### PR DESCRIPTION
Since 3.26.0, gnome-orca has been a transitional package which just
depends on orca.

https://phabricator.endlessm.com/T32987
