### PR TITLE
core: Remove eos-panel-extension

### DIFF
--- a/eos-core-depends
+++ b/eos-core-depends
@@ -64,7 +64,6 @@ eos-kalite-tools
 eos-kolibri-system-helper
 eos-media
 eos-metrics-instrumentation
-eos-panel-extension
 eos-phone-home
 eos-updater-tools
 eos-watermark-extension


### PR DESCRIPTION
The top-bar tweaks and dock which supersede this extension live in
eos-desktop-extension.

https://phabricator.endlessm.com/T33001
