### PR TITLE
Move PipeWire packages from os-depends to base-depends

### DIFF
--- a/base-depends
+++ b/base-depends
@@ -13,6 +13,9 @@ gstreamer1.0-plugins-good
 gstreamer1.0-tools
 gstreamer1.0-vaapi
 ibus-gtk3
+# pipewire-pulse must be listed before libcanberra-pulse, otherwise
+# it'll pull pulseaudio
+pipewire-pulse
 libcanberra-gtk3-module
 libcanberra-pulse
 libcaribou-gtk3-module
@@ -26,10 +29,14 @@ libgl1-nvidia-glvnd-glx [amd64]
 libglx-mesa0
 libnss-altfiles
 libnss-myhostname
+libspa-0.2-bluetooth
 locales-all
 lzma
 mawk
 netbase
+pipewire
+pipewire-audio-client-libraries
 sound-theme-freedesktop
+wireplumber
 xdg-utils
 xz-utils

--- a/os-depends
+++ b/os-depends
@@ -65,8 +65,6 @@ libpam-fprintd
 libpam-fscrypt
 libpam-runtime
 libpam-systemd
-# Bluetooth support for PipeWire
-libspa-0.2-bluetooth
 linux-firmware
 # Kernel package. All arm installs use platform specific kernels, so
 # those appear in the platform specific -depends files. For amd64,
@@ -97,9 +95,6 @@ ostree
 ostree-boot
 p7zip-full
 parted
-pipewire
-pipewire-audio-client-libraries
-pipewire-pulse
 # Used for the initial hardware evaluation
 plainbox-provider-checkbox
 policykit-1
@@ -121,7 +116,6 @@ usb-modeswitch
 vim-tiny
 virtualbox-guest-utils [amd64]
 virtualbox-guest-x11 [amd64]
-wireplumber
 wpasupplicant
 xauth
 xdg-user-dirs


### PR DESCRIPTION
We need to install it at the same time libcanberra-pulse is
installed, otherwise it inadvertedly pulls the pulseaudio
into the image.

https://phabricator.endlessm.com/T33042