### PR TITLE
os-depends: Install polkitd-javascript to migrate PKLA policies to JS rules

### DIFF
--- a/os-depends
+++ b/os-depends
@@ -97,7 +97,9 @@ p7zip-full
 parted
 # Used for the initial hardware evaluation
 plainbox-provider-checkbox
-policykit-1
+polkitd-javascript
+polkitd
+pkexec
 procps
 python3-gi
 rsync


### PR DESCRIPTION
Replace policykit-1 with polkitd-javascript, polkitd and pkexec to
migrate from old PKLA policies to JS rules.

https://phabricator.endlessm.com/T33151#927983