### PR TITLE
os-depends: Depend on firmware-sof-signed

### DIFF
--- a/os-depends
+++ b/os-depends
@@ -29,6 +29,7 @@ eos-version-number
 exfat-utils
 fdisk
 file
+firmware-sof-signed
 fonts-dejavu
 fscrypt
 # Used for the initial hardware evaluation


### PR DESCRIPTION
The commit ("UBUNTU: [Packaging] Downgrade firmware-sof-signed depends
to recommends") in linux-firmware makes firmware-sof-signed into
Recommends dependency, which leads EOS miss firmware-sof-signed, then
have no Intel SoF related firmware files.

This commit installs firmware-sof-signed again.

https://phabricator.endlessm.com/T33236#930671