### PR TITLE
os-depends: Install nvidia-driver-libs to support wayland using nvidia

### DIFF
--- a/os-depends
+++ b/os-depends
@@ -86,6 +86,7 @@ network-manager-gnome
 nftables
 ntfs-3g
 nvidia-driver-bin [amd64]
+nvidia-driver-libs [amd64]
 nvidia-kernel-drivers [amd64]
 nvidia-kernel-drivers-blob-signed [amd64]
 nvidia-modprobe [amd64]


### PR DESCRIPTION
Install nvidia-driver-libs to enable egl-wayland using nvidia feature.

https://phabricator.endlessm.com/T33217