### PR TITLE
os-depends: Install mesa-utils-extra for eglinfo command

### DIFF
--- a/os-depends
+++ b/os-depends
@@ -77,6 +77,7 @@ lsb-base
 lsb-release
 # Used for the initial hardware evaluation
 mesa-utils
+mesa-utils-extra
 mesa-vulkan-drivers
 mobile-broadband-provider-info
 mtr-tiny


### PR DESCRIPTION
Install mesa-utils-extra to have eglinfo command for wayland session.

https://phabricator.endlessm.com/T33217