### PR TITLE
os-depends: Install libgles-nvidia2 for NVIDIA cards

### DIFF
--- a/os-depends
+++ b/os-depends
@@ -62,6 +62,7 @@ kmod
 less
 # Needed to make gdb useful
 libc-dbg
+libgles-nvidia2 [amd64]
 libpam-fprintd
 libpam-fscrypt
 libpam-runtime


### PR DESCRIPTION
Install libgles-nvidia2 for NVIDIA cards

https://phabricator.endlessm.com/T33217