### PR TITLE
core: Add make

### DIFF
--- a/eos-core-depends
+++ b/eos-core-depends
@@ -176,6 +176,7 @@ libpipewire-0.3-common
 libsasl2-modules
 # Parental controls
 malcontent-gui
+make
 # For running the image builder from Endless
 mmdebstrap
 modemmanager


### PR DESCRIPTION
`make` is a generally useful utility that has no other dependencies
besides `libc6` and is only 1592 kB per the package `Installed-Size`. We
tend to think of `make` as a development tool, but people put all sorts
of recipes in a `Makefile`.