### PR TITLE
mimeapps: Dissociate ostree-repos from GNOME Software

### DIFF
--- a/debian/endless-mimeapps.list
+++ b/debian/endless-mimeapps.list
@@ -239,7 +239,6 @@ x-content/blank-bd=brasero-nautilus.desktop
 x-content/blank-cd=brasero-nautilus.desktop
 x-content/blank-dvd=brasero-nautilus.desktop
 x-content/blank-hddvd=brasero-nautilus.desktop
-x-content/ostree-repository=gnome-software-local-file.desktop
 x-content/software=nautilus-autorun-software.desktop
 x-content/video-dvd=org.gnome.Totem.desktop
 x-content/video-svcd=org.gnome.Totem.desktop


### PR DESCRIPTION
Previously, inserting a USB drive with an OSTree repo at its root would
cause Nautilus to prompt it to be opened with "Software Install". This
used to be correct, but when updating to GNOME Software 41 we dropped
our downstream support for USB updates.

This spiritually reverts 044c635e ("defaults: Associate GNOME Software
with ostree repos") and can be in turn reverted as and when Software
supports USB OS & app updates again.

https://phabricator.endlessm.com/T33546
