### PR TITLE
base-depends: Depend on pipewire-alsa

### DIFF
--- a/base-depends
+++ b/base-depends
@@ -35,7 +35,7 @@ lzma
 mawk
 netbase
 pipewire
-pipewire-audio-client-libraries
+pipewire-alsa
 sound-theme-freedesktop
 wireplumber
 xdg-utils


### PR DESCRIPTION
In Debian's pipewire 0.3.54-1, the old pipewire-audio-client-libraries
package was split into pipewire-alsa and pipewire-jack.
https://salsa.debian.org/utopia-team/pipewire/-/commit/c17c45740d5efa5c8fec8acbfb359be33c73a52d

pipewire-alsa contains alsa plugins for pcm and ctl using pipewire. The
package (like pipewire-audio-client-libraries) drops a symlink into
/etc/alsa/conf.d pointing to
/usr/share/alsa/alsa.conf.d/50-pipewire.conf which causes these to be
used. (It also contains an example in /usr/share/doc/pipewire/examples
for how to make PipeWire the default ALSA output; we don't use this at
present.)

pipewire-jack contains alternative implementations of the JACK client
libraries, implemented in terms of Pipewire. These are not on the
library path by default (though there is an example for how to do it in
/usr/share/doc/pipewire/examples). It also contains the 'pw-jack'
command which can be used to run a single program with LD_LIBRARY_PATH
adjusted to load these libraries.

https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=994165 talks about
making the pipewire-jack package actually provide the Pipewire-based
JACK libraries directly on the default library path, but that does not
appear to currently be the case.

In any case, we don't have any applications in the OS that use the JACK client
library, and modern Flatpak runtimes ship these pipewire-based versions of
the JACK client library. (The host libraries would not be used either
way.) So while it would be harmless to ship it, we don't need this
package on Endless OS.

https://phabricator.endlessm.com/T33689
