### PR TITLE
os-depends: Install more nvidia libs for GBM with NVIDIA device

### DIFF
--- a/os-depends
+++ b/os-depends
@@ -63,6 +63,8 @@ less
 # Needed to make gdb useful
 libc-dbg
 libgles-nvidia2 [amd64]
+libnvidia-allocator1 [amd64]
+libnvidia-egl-gbm1 [amd64]
 libpam-fprintd
 libpam-fscrypt
 libpam-runtime


### PR DESCRIPTION
Install libnvidia-allocator1 and libnvidia-egl-gbm1 for GBM with NVIDIA
devices.

https://phabricator.endlessm.com/T33820