### PR TITLE
os-depends: Install switcheroo-control for dedicated Graphics cards

### DIFF
--- a/os-depends
+++ b/os-depends
@@ -113,6 +113,7 @@ smartmontools
 spice-vdagent
 spice-webdavd
 sudo
+switcheroo-control
 # Used for booting unified kernel EFI image on PAYG
 systemd-boot-signed [amd64]
 systemd-sysv


### PR DESCRIPTION
Install switcheroo-control to let the user choose using integrated, or
the other GPU, if there are more than one GPU in the system.

https://phabricator.endlessm.com/T33814