### PR TITLE
os-depends: Install systemd-boot

### DIFF
--- a/os-depends
+++ b/os-depends
@@ -117,7 +117,7 @@ spice-webdavd
 sudo
 switcheroo-control
 # Used for booting unified kernel EFI image on PAYG
-systemd-boot-signed [amd64]
+systemd-boot [amd64]
 systemd-sysv
 systemd
 udev


### PR DESCRIPTION
Debian's new systemd (since 251.2-3) places the EFI stub into systemd-boot-efi package which EOS uses for the PAYG platforms. So, for the new schema, EOS signs it as systemd-boot-efi-signed to be installed.

Besides, systemd-boot-efi-signed is the dependent package of EOS' systemd-boot. Therefore, install the systemd-boot for PAYG systems.

Fixes: 8721ff2214cf ("os-depends: Add systemd-boot-signed") https://phabricator.endlessm.com/T33862