### PR TITLE
Make base-files with epoch become conflict

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -15,7 +15,8 @@ Replaces: endless-core
 Provides: endless-core
 Conflicts: endless-core,
            libwebkit2gtk-4.0-37 (>= 1:2.18.4),
-           libjavascriptcoregtk-4.0-18 (>= 1:2.18.4)
+           libjavascriptcoregtk-4.0-18 (>= 1:2.18.4),
+           base-files (>= 1:10.1)
 Depends: ${misc:Depends}, ${eos:Depends}
 Description: Target packages of the Endless distribution
  This package depends on all packages required for the Endless OS core images


### PR DESCRIPTION
EOS 5+ tries to install the base-files without epoch in the version string which uses the same schema as Debian's base-files. Therfore, add the prevoius EOS base-files with epoch into the conflict list.

https://phabricator.endlessm.com/T33521