### PR TITLE
os-depends: Install systemd-timesyncd

### DIFF
--- a/os-depends
+++ b/os-depends
@@ -119,6 +119,7 @@ switcheroo-control
 # Used for booting unified kernel EFI image on PAYG
 systemd-boot [amd64]
 systemd-sysv
+systemd-timesyncd
 systemd
 udev
 usb-modeswitch


### PR DESCRIPTION
Debian's new systemd (since 247.9-2) moves systemd-timesyncd from Depends to Recommends. But, EOS does not install the recommended dependent packages by default. To have the NTP, let's install systemd-timesyncd.

https://phabricator.endlessm.com/T33863