### PR TITLE
eos-diagnostics: Add RTC information

### DIFF
--- a/eos-tech-support/eos-diagnostics
+++ b/eos-tech-support/eos-diagnostics
@@ -535,6 +535,10 @@ let diagnostics = [
         },
     },
     {
+        title: 'RTC',
+        content: function() { return tryReadFile('/proc/driver/rtc'); },
+    },
+    {
         title: 'Disks',
         hardwareInfo: true,
         content: function() { return trySpawn('udisksctl dump'); },


### PR DESCRIPTION
Add the RTC information for timing, especially for the PAYG feature.

We understand that the batt_status field may not be accurate, for example the mail on the internet: RTC batt_status always okay [1]. However, if "batt_status" shows "dead", then it must be something wrong. The field information might be improved by Linux kernel in the future.

[1]: https://lkml.iu.edu/hypermail/linux/kernel/1610.0/00094.html

https://phabricator.endlessm.com/T33898