### PR TITLE
os-depends: Install systemd-oomd

### DIFF
--- a/os-depends
+++ b/os-depends
@@ -118,6 +118,7 @@ sudo
 switcheroo-control
 # Used for booting unified kernel EFI image on PAYG
 systemd-boot [amd64]
+systemd-oomd
 systemd-sysv
 systemd-timesyncd
 systemd


### PR DESCRIPTION
We are replacing our own psi-monitor with systemd-oomd.

https://phabricator.endlessm.com/T23914