### PR TITLE
Readd pulseaudio-utils to the OS

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -135,6 +135,7 @@ Architecture: all
 Depends: ${eos:Depends},
          ${misc:Depends},
          ostree (>= 2018.8),
+         pulseaudio-utils,
          usbutils,
 Description: EndlessOS Technical Support Tools
  This is a collection of technical support tools that are installed by default

--- a/os-depends
+++ b/os-depends
@@ -108,6 +108,7 @@ polkitd-javascript
 polkitd
 pkexec
 procps
+pulseaudio-utils
 python3-gi
 rsync
 shim-efi-image-signed [amd64]


### PR DESCRIPTION
… in 2 different ways for 2 different reasons, described in each commit.

(Actually there is a third reason we might want this: files installed by checkbox contains many references to `pactl`.)

https://phabricator.endlessm.com/T34099