### PR TITLE
Ship udev rules for Android devices & gaming controllers

### DIFF
--- a/eos-core-depends
+++ b/eos-core-depends
@@ -17,6 +17,8 @@ hunspell-vi
 alsa-topology-conf
 alsa-ucm-conf
 alsa-utils
+# udev rules to allow unprivileged adb access to Android devices over USB
+android-sdk-platform-tools-common
 apt
 apt-utils
 avahi-daemon

--- a/eos-core-depends
+++ b/eos-core-depends
@@ -210,6 +210,8 @@ slirp4netns
 smbclient
 sound-icons
 speech-dispatcher-espeak-ng
+# udev rules for games controllers (T33130)
+steam-devices
 strace
 system-config-printer-common
 system-config-printer-udev


### PR DESCRIPTION
Today I tried to use `adb` to do something on my Android phone, and it was made harder by the lack of appropriate udev rules to set permissions on the device.

Then I remembered a similar ticket I filed almost a year ago about Steam.

https://phabricator.endlessm.com/T33130
