### PR TITLE
core: Add fwupd

### DIFF
--- a/eos-core-depends
+++ b/eos-core-depends
@@ -106,6 +106,8 @@ fonts-uralic
 foomatic-db-compressed-ppds
 force-quit-dialog-extension
 fprintd
+fwupd
+fwupd-signed [amd64]
 # For rootless podman
 fuse-overlayfs
 gdb


### PR DESCRIPTION
Install fwupd to manage firmware updates. The signed version is only available for amd64, which is fine since that's the only architecture where we use UEFI. Unlike our other signed packages, fwupd-signed does not replace fwupd.

https://phabricator.endlessm.com/T31024