### PR TITLE
core: Add bootupd

### DIFF
--- a/eos-core-depends
+++ b/eos-core-depends
@@ -27,6 +27,7 @@ avahi-utils
 baobab
 bluez-obexd
 bolt
+bootupd
 brasero
 brasero-cdrkit
 # Provides the default --init executable for podman


### PR DESCRIPTION
This will be used to update boot components such as UEFI programs that are managed outside of the ostree.

This depends on the package being added first in https://obs-master.endlessm-sf.com/request/show/23104.

https://phabricator.endlessm.com/T14870