### PR TITLE
Revert "Don't autoinstall AdBlock Plus"

### DIFF
--- a/eos-core-depends
+++ b/eos-core-depends
@@ -50,6 +50,7 @@ efitools [amd64]
 elfutils
 eog
 eos-acknowledgements
+eos-adblock-plus-extensions
 eos-b43fw-install
 eos-browser-tools
 eos-desktop-extension


### PR DESCRIPTION
This reverts commit 90ada88ed00e7a8ffc1fcefccbb3e4fcde1fdb6e.

This has the side-effect of removing /usr/share/chromium, which causes
Chromium to fail to start:

    Apr 18 20:23:04 camille org.chromium.Chromium.flextop.chrome-hnpfjngllnobngcgfapefoaidbinmjnm-Default.desktop[3649]: bwrap: Can't find source path /var/lib/flatpak/extension/org.chromium.Chromium.Extension.system-extensions/x86_64/1: No such file or directory

Back it out for now.

https://phabricator.endlessm.com/T34534
