### PR TITLE
os: Depend on nvidia-suspend-common

### DIFF
--- a/os-depends
+++ b/os-depends
@@ -96,6 +96,7 @@ nvidia-driver-libs [amd64]
 nvidia-kernel-drivers [amd64]
 nvidia-kernel-drivers-blob-signed [amd64]
 nvidia-modprobe [amd64]
+nvidia-suspend-common [amd64]
 open-vm-tools-desktop [amd64]
 openssh-client
 ostree


### PR DESCRIPTION
The gdm will need the scripts from nvidia-suspend-common to enable Wayland on the models equippied with NVIDIA card since gdm v43.x.

https://phabricator.endlessm.com/T34956