### PR TITLE
Increase test timeout time

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -10,5 +10,6 @@ if get_option('check-deps')
     env : [
       'DH_VERBOSE=1',
     ],
+    timeout : 60,
   )
 endif


### PR DESCRIPTION
This test constructs a massive `apt-get install` line to check that the
metapackages are installable. It keeps hitting Meson's default 30-second
timeout in Jenkins.

Make the number bigger!
