### PR TITLE
Remove gstreamer1.0-vaapi from OS

### DIFF
--- a/base-depends
+++ b/base-depends
@@ -11,7 +11,6 @@ gnome-accessibility-themes
 gstreamer1.0-libav
 gstreamer1.0-plugins-good
 gstreamer1.0-tools
-gstreamer1.0-vaapi
 ibus-gtk3
 # pipewire-pulse must be listed before libcanberra-pulse, otherwise
 # it'll pull pulseaudio


### PR DESCRIPTION
We do not ship VAAPI drivers in the OS.

Previously, we added symbolic links to pick up the drivers from a
Flatpak, if installed, but we are removing these because:

1. The drivers stopped working on the host for unknown reasons
2. Very little in the base OS uses GStreamer anyway

So there is no need to ship these libva-based GStreamer elements. They
never previously worked anyway, because we previously shipped a
systemwide GStreamer element cache which was precomputed on our build
server which did not have VAAPI drivers installed, and was not
recomputed if the VAAPI drivers were installed client-side.

https://phabricator.endlessm.com/T32994
https://phabricator.endlessm.com/T34998
