### PR TITLE
Don't autoinstall AdBlock Plus

### DIFF
--- a/eos-core-depends
+++ b/eos-core-depends
@@ -50,7 +50,6 @@ efitools [amd64]
 elfutils
 eog
 eos-acknowledgements
-eos-adblock-plus-extensions
 eos-b43fw-install
 eos-browser-tools
 eos-desktop-extension


### PR DESCRIPTION
It has been noted that the first-run page that is displayed when you
first open a browser very strongly guides you to donate €35.  You might
reasonably (but wrongly) think this is Endless asking you for money.
This honor-ware page is also occasionally shown when the extension is
updated.

Stop autoinstalling AdBlock Plus. The 'eos-adblock-plus-extensions'
package just contains a tiny JSON file that instructs Chrome and
Chromium to install AdBlock Plus when it first launches. Existing users
will, I believe, keep the extension.

This is a second attempt to land https://github.com/endlessm/eos-meta/pull/761,
this time taking care to remove the corresponding tmpfiles.d snippet first:

- [x] https://github.com/endlessm/eos-boot-helper/pull/386

https://phabricator.endlessm.com/T34534


