### PR TITLE
eos-write-installer: Add `partprobe` to dependencies

### DIFF
--- a/eos-tech-support/eos-write-installer
+++ b/eos-tech-support/eos-write-installer
@@ -109,6 +109,7 @@ declare -A dependencies
 dependencies=(
     [dd]='coreutils'
     [mkfs.exfat]='exfat-utils'
+    [partprobe]='parted'
     [pv]='pv'
     [xzcat]='xz-utils'
     [zcat]='gzip'


### PR DESCRIPTION
Ran into this when using Silverblue; I needed to install `parted` to be able to use `partprobe`, otherwise it failed with:

```
eos-write-image: line 222: partprobe: command not found
```