### PR TITLE
Install ibus-mozc, not ibus-anthy, for Japanese input

### DIFF
--- a/eos-core-depends
+++ b/eos-core-depends
@@ -134,7 +134,6 @@ gstreamer1.0-gl
 gvfs-backends
 gvfs-fuse
 htop
-ibus-anthy
 ibus-avro
 ibus-cangjie
 ibus-hangul
@@ -143,6 +142,7 @@ ibus-libpinyin
 ibus-libthai
 ibus-libzhuyin
 ibus-m17n
+ibus-mozc
 ibus-table-wubi
 ibus-unikey
 # For screen rotation support


### PR DESCRIPTION
GNOME upstream prefers anthy, but Debian and Ubuntu prefer mozc.
Debian's gnome-desktop package (which we use) is patched to prefer mozc.

No migration is provided for existing anthy users, who will need to
reconfigure their input method.

https://phabricator.endlessm.com/T35060
