### PR TITLE
Replace exfat-utils with exfatprogs

### DIFF
--- a/eos-tech-support/eos-write-installer
+++ b/eos-tech-support/eos-write-installer
@@ -108,7 +108,7 @@ fi
 declare -A dependencies
 dependencies=(
     [dd]='coreutils'
-    [mkfs.exfat]='exfat-utils'
+    [mkfs.exfat]='exfatprogs'
     [partprobe]='parted'
     [pv]='pv'
     [xzcat]='xz-utils'

--- a/eos-tech-support/eos-write-live-image
+++ b/eos-tech-support/eos-write-live-image
@@ -274,7 +274,7 @@ else
     # files.  As a compromise, force the cluster size to 64 sectors, i.e. 32
     # KiB, which is the default for volumes between 256 MiB and 32 GiB.
     MKFS_ARGS='-s 64 -n'
-    dependencies[$MKFS_IMAGES]='exfat-utils'
+    dependencies[$MKFS_IMAGES]='exfatprogs'
 fi
 
 if [ "$EXPAND" ]; then

--- a/eos-tech-support/eos-write-live-image
+++ b/eos-tech-support/eos-write-live-image
@@ -271,9 +271,10 @@ else
     # the disk size.  On large disks this is 128 KiB, wasting a lot of space on
     # Endless Key with many small files.  Using 4 KiB (the default for very
     # small disks) appears to have some performance impact when reading large
-    # files.  As a compromise, force the cluster size to 64 sectors, i.e. 32
-    # KiB, which is the default for volumes between 256 MiB and 32 GiB.
-    MKFS_ARGS='-s 64 -n'
+
+    # files.  As a compromise, force the cluster size to 32 KiB, which is the
+    # default for volumes between 256 MiB and 32 GiB.
+    MKFS_ARGS='-c 32k -L'
     dependencies[$MKFS_IMAGES]='exfatprogs'
 fi
 

--- a/os-depends
+++ b/os-depends
@@ -26,7 +26,7 @@ eos-plymouth-theme
 eos-tech-support
 eos-updater
 eos-version-number
-exfat-utils
+exfatprogs
 fdisk
 file
 firmware-sof-signed


### PR DESCRIPTION
exfat-utils came from the FUSE implementation of exFAT and have been
removed from Bookworm.

exfatprogs are from the team that submitted & maintain the in-kernel
exFAT implementation.


https://phabricator.endlessm.com/T35035