### PR TITLE
eos-core: Remove gnome-screenshot

### DIFF
--- a/eos-core-depends
+++ b/eos-core-depends
@@ -117,7 +117,6 @@ gnome-keyring-pkcs11
 gnome-menus
 gnome-online-accounts
 gnome-remote-desktop
-gnome-screenshot
 gnome-shell-extension-appindicator
 gnome-software
 gnome-software-plugin-flatpak


### PR DESCRIPTION
GNOME Shell 43 includes a built-in screenshot tool.

gnome-screenshot 41 is still present in Bookworm but installing it means that a desktop search for "screenshot" produces two confusingly-similar results.

![image](https://github.com/endlessm/eos-meta/assets/86760/b23c9a65-f5df-42bd-97e0-8affc67ce72d)

https://phabricator.endlessm.com/T35034