### PR TITLE
eos-core: Remove eos-hack-extension

### DIFF
--- a/eos-core-depends
+++ b/eos-core-depends
@@ -53,7 +53,6 @@ eos-event-recorder-daemon
 eos-flatpak-autoinstall
 eos-gates
 eos-google-chrome-helper [amd64]
-eos-hack-extension
 eos-installer
 eos-kalite-system-helper
 eos-kalite-tools


### PR DESCRIPTION
This extension is not compatible with gnome-shell 43, and we are no longer developing Hack.

https://phabricator.endlessm.com/T35054