### PR TITLE
base-depends: Add ibus-gtk4

### DIFF
--- a/base-depends
+++ b/base-depends
@@ -12,6 +12,7 @@ gstreamer1.0-libav
 gstreamer1.0-plugins-good
 gstreamer1.0-tools
 ibus-gtk3
+ibus-gtk4
 # pipewire-pulse must be listed before libcanberra-pulse, otherwise
 # it'll pull pulseaudio
 pipewire-pulse


### PR DESCRIPTION
EOS 5.1(+) includes many GTK 4 applications in the base OS. So, add ibus-gtk4 to support input methods.

https://phabricator.endlessm.com/T35149