### PR TITLE
eos-core-depends: eos-toolbox-dev-depends: Add netavark & aardvark-dns

### DIFF
--- a/eos-core-depends
+++ b/eos-core-depends
@@ -14,6 +14,7 @@ hunspell-pt-br
 hunspell-th
 hunspell-vi
 
+aardvark-dns
 alsa-topology-conf
 alsa-ucm-conf
 alsa-utils
@@ -176,6 +177,7 @@ malcontent-gui
 mmdebstrap
 modemmanager
 nautilus
+netavark
 network-manager-l2tp-gnome
 network-manager-openconnect-gnome 
 network-manager-openvpn-gnome

--- a/eos-core-depends
+++ b/eos-core-depends
@@ -31,6 +31,7 @@ bolt
 # Provides the default --init executable for podman
 catatonit
 cdrdao
+console-data
 cracklib-runtime
 # Runtime for podman containers
 crun

--- a/eos-core-depends
+++ b/eos-core-depends
@@ -189,6 +189,7 @@ orca
 patch
 podman
 podman-toolbox
+power-profiles-daemon
 # For modem support
 ppp
 printer-driver-all-enforce

--- a/eos-toolbox-dev-depends
+++ b/eos-toolbox-dev-depends
@@ -11,6 +11,7 @@
 # size quite substantially. Developers that need the extra packages can
 # still install them manually using apt-get from an eos-toolbox container.
 
+aardvark-dns
 acl
 apt-file
 apt-utils
@@ -45,6 +46,7 @@ man-db
 manpages
 meson
 net-tools
+netavark
 obs-build
 openssh-client
 osc


### PR DESCRIPTION
Add netavark & aardvark-dns for Podman 4.0(+)'s new network stack. [1]

[1]: https://www.redhat.com/sysadmin/podman-new-network-stack

https://phabricator.endlessm.com/T35149