### PR TITLE
Remove obsolete conflicts

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -13,9 +13,7 @@ Package: eos-core
 Architecture: any
 Replaces: endless-core
 Provides: endless-core
-Conflicts: endless-core,
-           libwebkit2gtk-4.0-37 (>= 1:2.18.4),
-           libjavascriptcoregtk-4.0-18 (>= 1:2.18.4)
+Conflicts: endless-core
 Depends: ${misc:Depends}, ${eos:Depends}
 Description: Target packages of the Endless distribution
  This package depends on all packages required for the Endless OS core images

--- a/debian/control
+++ b/debian/control
@@ -1,7 +1,7 @@
 Source: eos-meta
 Section: metapackages
 Priority: optional
-Maintainer: EndlessM Maintainers <maintainers@endlessm.com>
+Maintainer: Endless OS Maintainers <maintainers@endlessos.org>
 Uploaders: Sjoerd Simons <sjoerd.simons@collabora.co.uk>, Hector Oron <hector.oron@collabora.co.uk>, Srdjan Grubor <sgnn7@sgnn7.org>
 Standards-Version: 3.9.3
 Build-Depends: debhelper (>= 9),

--- a/debian/control
+++ b/debian/control
@@ -11,9 +11,6 @@ Homepage: http://www.endlessm.com
 
 Package: eos-core
 Architecture: any
-Replaces: endless-core
-Provides: endless-core
-Conflicts: endless-core
 Depends: ${misc:Depends}, ${eos:Depends}
 Description: Target packages of the Endless distribution
  This package depends on all packages required for the Endless OS core images

--- a/debian/control
+++ b/debian/control
@@ -15,8 +15,7 @@ Replaces: endless-core
 Provides: endless-core
 Conflicts: endless-core,
            libwebkit2gtk-4.0-37 (>= 1:2.18.4),
-           libjavascriptcoregtk-4.0-18 (>= 1:2.18.4),
-           base-files (>= 1:10.1)
+           libjavascriptcoregtk-4.0-18 (>= 1:2.18.4)
 Depends: ${misc:Depends}, ${eos:Depends}
 Description: Target packages of the Endless distribution
  This package depends on all packages required for the Endless OS core images

--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,6 @@ Source: eos-meta
 Section: metapackages
 Priority: optional
 Maintainer: Endless OS Maintainers <maintainers@endlessos.org>
-Uploaders: Sjoerd Simons <sjoerd.simons@collabora.co.uk>, Hector Oron <hector.oron@collabora.co.uk>, Srdjan Grubor <sgnn7@sgnn7.org>
 Standards-Version: 3.9.3
 Build-Depends: debhelper (>= 9),
                libdpkg-perl,

--- a/debian/copyright
+++ b/debian/copyright
@@ -1,5 +1,5 @@
 Copyright 2012, Collabora Ltd.
-Copyright © 2013 Endless Mobile, Inc.  All rights reserved.
+Copyright 2013–2014 Endless OS Foundation LLC
 
 This program is free software; you can redistribute it and/or modify it under
 the terms of the GNU General Public License as published by the Free Software


### PR DESCRIPTION
Spotted while investigating why we have three copies of WebKitGTK in the OS.