### PR TITLE
eos-core-depends: Add console-common

### DIFF
--- a/eos-core-depends
+++ b/eos-core-depends
@@ -31,6 +31,7 @@ bolt
 # Provides the default --init executable for podman
 catatonit
 cdrdao
+console-common
 console-data
 cracklib-runtime
 # Runtime for podman containers


### PR DESCRIPTION
Install console-common to have the install-keymap utility, which is the recommended tool to specify a boot-time keymap to the system.

https://phabricator.endlessm.com/T35149