### PR TITLE
os-depends: Add x11-utils

### DIFF
--- a/os-depends
+++ b/os-depends
@@ -133,6 +133,8 @@ vim-tiny
 virtualbox-guest-utils [amd64]
 virtualbox-guest-x11 [amd64]
 wpasupplicant
+# Required for the Xwayland-session script in at-spi2-core
+x11-utils
 xauth
 xdg-user-dirs
 xdg-user-dirs-gtk


### PR DESCRIPTION
The xprop utility, provided by x11-utils, is required by an Xwayland session script included in at-spi2-core.

https://phabricator.endlessm.com/T35173