### PR TITLE
eos-diagnostics: Collect extra PAYG logs

### DIFF
--- a/eos-tech-support/eos-diagnostics
+++ b/eos-tech-support/eos-diagnostics
@@ -763,6 +763,33 @@ let diagnostics = [
         }
     },
     {
+        title: 'PAYG logs',
+        content() {
+            let logDir = Gio.File.new_for_path("/var/log/eos-payg");
+            let enumerator, fileInfos;
+
+            try {
+                enumerator = logDir.enumerate_children('standard::name', Gio.FileQueryInfoFlags.NONE, null);
+                fileInfos = Array.from(enumerator);
+            } catch (e) {
+                return '';
+            }
+
+            /* Log files are named eos-paygd-YYYYMMDD.log; sort chronologically */
+            fileInfos.sort((a, b) => a.get_name().localeCompare(b.get_name()));
+
+            let decoder = new TextDecoder('utf-8', {fatal: false});
+            return fileInfos.map(fileInfo => {
+                try {
+                    const [ok, contents, length] = enumerator.get_child(fileInfo).load_contents(null);
+                    return fileInfo.get_name() + '\n' + decoder.decode(contents);
+                } catch (e) {
+                    return '' + e;
+                }
+            }).join('\n');
+        }
+    },
+    {
         title: 'Coredump',
         coredumpInfo: true,
         content: function() {


### PR DESCRIPTION
eos-paygd writes extra logs to /var/log/eos-payg. These are useful on
systems where the journal is not persistent; and when we want deeper
history of PAYG state changes after the journal has been rotated.

I tested the following error cases:

- /var/log/eos-payg does not exist or is not readable; in this case the
  section is omitted. This should not happen in practice – the
  tmpfiles.d snippet sets mode 755.
- A file within is not readable; in this case the exception is included
  in the diagnostic file.
- A file within contains invalid UTF-8; in this case the replacement
  character is used.

If the directory is empty, the function returns empty string, which
means the section is omitted.

https://phabricator.endlessm.com/T33896
