### PR TITLE
Remove eos-watermark-extension from OS

### DIFF
--- a/eos-core-depends
+++ b/eos-core-depends
@@ -63,7 +63,6 @@ eos-media
 eos-metrics-instrumentation
 eos-phone-home
 eos-updater-tools
-eos-watermark-extension
 evince
 evolution
 # For spam filtering


### PR DESCRIPTION
This is very lightly used, not enough to justify updating it for GNOME
43 compatibility.

If we wish to bring this functionality back in future, we should instead
package https://pagure.io/background-logo-extension, which is actually
the ancestral source of the eos-watermark-extension code and which is
actively maintained by a core Shell developer for each Fedora release.

https://phabricator.endlessm.com/T35077