### PR TITLE
Remove gstreamer1.0-libav from OS

### DIFF
--- a/base-depends
+++ b/base-depends
@@ -8,7 +8,6 @@ fonts-lato
 fonts-liberation
 fonts-wqy-microhei
 gnome-accessibility-themes
-gstreamer1.0-libav
 gstreamer1.0-plugins-good
 gstreamer1.0-tools
 ibus-gtk3

--- a/eos-tech-support/eos-diagnostics
+++ b/eos-tech-support/eos-diagnostics
@@ -643,7 +643,6 @@ let diagnostics = [
         title: 'Codecs',
         content: function() {
             return trySpawn('find /var/lib/codecs') + '\n' +
-                   trySpawn('gst-inspect-1.0 libav') +
                    trySpawn('gst-inspect-1.0 -b');
         },
     },


### PR DESCRIPTION
gstreamer1.0-libav provides a gstreamer plugin that proxies to ffmpeg's codecs via its various libav* libraries. In theory that's nice since gstreamer applications can gain access to ffmpeg's codecs. In practice we were trimming down ffmpeg so much that it probably does not provide codecs for any media types that weren't already provided by native gstreamer plugins.

Furthermore, nothing we ship appears to have a hard dependency on the gstreamer elements provided by the libva plugin. We've also dropped the `/var/lib/codecs` system that provided the less patent encumbered ffmpeg extra libraries.

By extension, this also removes the ffmpeg libraries since gstreamer1.0-libav was the only thing we shipped using them. That simplifies our development by not having to analyze the legality of all the ffmpeg codecs and adjust the build to fit.

https://phabricator.endlessm.com/T35225