### PR TITLE
Revert "Remove gstreamer1.0-libav from OS"

### DIFF
--- a/base-depends
+++ b/base-depends
@@ -8,6 +8,7 @@ fonts-lato
 fonts-liberation
 fonts-wqy-microhei
 gnome-accessibility-themes
+gstreamer1.0-libav
 gstreamer1.0-plugins-good
 gstreamer1.0-tools
 ibus-gtk3

--- a/eos-tech-support/eos-diagnostics
+++ b/eos-tech-support/eos-diagnostics
@@ -643,6 +643,7 @@ let diagnostics = [
         title: 'Codecs',
         content: function() {
             return trySpawn('find /var/lib/codecs') + '\n' +
+                   trySpawn('gst-inspect-1.0 libav') +
                    trySpawn('gst-inspect-1.0 -b');
         },
     },


### PR DESCRIPTION
This reverts commit 73f27a845db9f92b2197f6430af4dd0621578322. It turns out that freerdp still uses ffmpeg and we don't want to go upending things at this stage in our development. As long as ffmpeg is going to be in the OS, we might as well make the components available to gstreamer applications.

https://phabricator.endlessm.com/T35225