### PR TITLE
mimeapps: Remove endlessm-app: handler

### DIFF
--- a/debian/endless-mimeapps.list
+++ b/debian/endless-mimeapps.list
@@ -239,7 +239,6 @@ x-content/software=nautilus-autorun-software.desktop
 x-content/video-dvd=org.gnome.Totem.desktop
 x-content/video-svcd=org.gnome.Totem.desktop
 x-content/video-vcd=org.gnome.Totem.desktop
-x-scheme-handler/endlessm-app=eos-launch.desktop
 x-scheme-handler/ghelp=org.gnome.Yelp.desktop
 x-scheme-handler/help=org.gnome.Yelp.desktop
 x-scheme-handler/http=org.chromium.Chromium.desktop


### PR DESCRIPTION
eos-launch.desktop has been removed, and the use of the endlessm-app: scheme with it.

https://phabricator.endlessm.com/T31635
