### PR TITLE
eos-core: Add containers-storage for podman

### DIFF
--- a/eos-core-depends
+++ b/eos-core-depends
@@ -32,6 +32,8 @@ bolt
 catatonit
 cdrdao
 console-data
+# Provides the default storage configuration for podman
+containers-storage
 cracklib-runtime
 # Runtime for podman containers
 crun


### PR DESCRIPTION
It provides `/usr/share/containers/storage.conf`, which contains sane storage settings that are different than the settings statically linked into podman. In particular, it sets the default driver to `overlay` rather than the builtin default of `vfs`.

https://phabricator.endlessm.com/T35229