### PR TITLE
Revert "Revert "Remove gstreamer1.0-libav from OS""

### DIFF
--- a/base-depends
+++ b/base-depends
@@ -8,7 +8,6 @@ fonts-lato
 fonts-liberation
 fonts-wqy-microhei
 gnome-accessibility-themes
-gstreamer1.0-libav
 gstreamer1.0-plugins-good
 gstreamer1.0-tools
 ibus-gtk3

--- a/eos-tech-support/eos-diagnostics
+++ b/eos-tech-support/eos-diagnostics
@@ -643,7 +643,6 @@ let diagnostics = [
         title: 'Codecs',
         content: function() {
             return trySpawn('find /var/lib/codecs') + '\n' +
-                   trySpawn('gst-inspect-1.0 libav') +
                    trySpawn('gst-inspect-1.0 -b');
         },
     },


### PR DESCRIPTION
This reverts commit 9439f13f3b723f128fac99fde39a41ee25287c24. For real this time. The only other user of ffmpeg was freerdp, and it was actually useless since our ffmpeg doesn't have H.264 codecs. So, freerdp has been changed to not build against ffmpeg and now gstreamer1.0-libav is the last user of it. After this, EOS will be free of ffmpeg.

https://phabricator.endlessm.com/T35225