### PR TITLE
core: Add containernetworking-plugins

### DIFF
--- a/eos-core-depends
+++ b/eos-core-depends
@@ -32,6 +32,8 @@ bolt
 catatonit
 cdrdao
 console-data
+# podman's configuration refers to plugins from this package
+containernetworking-plugins
 # Provides the default storage configuration for podman
 containers-storage
 cracklib-runtime


### PR DESCRIPTION
/etc/cni/net.d/87-podman-bridge.conflist refers to several plugins from
this package; without it, attempting to run some configurations of
containers (such as via docker-compose) fails with errors like:

> ERROR: for postgres  preparing container
> 3e95923481bbf2f48645eff5da2c92e84b40f723f518153d270f703269fb3752 for
> attach: plugin type="bridge" failed (add): failed to find plugin
> "bridge" in path [/usr/local/libexec/cni /usr/libexec/cni
> /usr/local/lib/cni /usr/lib/cni /opt/cni/bin]

With this package installed, `docker-compose` can be used successfully
from a toolbox container against podman on the host.

It is 45 MiB which I feel a bit bad about, but maybe we can reclaim that
somewhere else in the OS.
