### PR TITLE
os-depends: Avoid install old EOS downstream pulseaudio packages

### DIFF
--- a/os-depends
+++ b/os-depends
@@ -112,7 +112,7 @@ polkitd-javascript
 polkitd
 pkexec
 procps
-pulseaudio-utils
+pulseaudio-utils (< 1:0.0)
 python3-gi
 rsync
 shim-efi-image-signed [amd64]


### PR DESCRIPTION
EOS has dropped EOS downstream pulseaudio with epoch version and use the pulseaudio related packages from Debian directly since EOS 6.0. However, the epoch version makes EOS' downstream pulseaudio newer than Debian's. It is okay for OSTree, because EOS build each OSTree commit from fresh installation. But, the version conflict will happen in container and eos-dev-unlock systems when do "apt upgrade". So, add the version constraint to pulseaudio-utils package to avoid the version conflict.

https://phabricator.endlessm.com/T35072