### PR TITLE
Stop installing eos-link-feedback.desktop

### DIFF
--- a/debian/eos-tech-support.install
+++ b/debian/eos-tech-support.install
@@ -1,2 +1,1 @@
 eos-tech-support/eos-* usr/bin
-eos-tech-support/data/*.desktop usr/share/applications

--- a/eos-tech-support/data/eos-link-feedback.desktop
+++ b/eos-tech-support/data/eos-link-feedback.desktop
@@ -1,7 +1,0 @@
-[Desktop Entry]
-Version=1.0
-Name=Feedback
-Type=Application
-Exec=gio open https://community.endlessos.com/
-Categories=Utility;
-NoDisplay=true


### PR DESCRIPTION
eos-panel-extension used to have a menu item which invoked this (hidden) desktop file, which opens our forum in the web browser.

Since EOS 5 we have not used eos-panel-extension, so this desktop file is unused. Our forum is now available to “install” (as an Epiphany web app) from GNOME Software.