### PR TITLE
eos-download-image: Use packaging.version.Version

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -128,6 +128,7 @@ Architecture: all
 Depends: ${eos:Depends},
          ${misc:Depends},
          ostree (>= 2018.8),
+         python3-packaging,
          pulseaudio-utils,
          usbutils,
 Description: EndlessOS Technical Support Tools

--- a/eos-tech-support/eos-download-image
+++ b/eos-tech-support/eos-download-image
@@ -4,10 +4,10 @@ import argparse
 import collections
 import datetime
 import dateutil.parser
-import distutils.version
 import gzip
 import json
 import os
+import packaging.version
 import requests
 import shlex
 import subprocess
@@ -349,7 +349,7 @@ class EosDownloadImage(object):
 
         manifest = response.json()
         images = list(manifest['images'].values())
-        images.sort(key=lambda i: distutils.version.LooseVersion(i['version']))
+        images.sort(key=lambda i: packaging.version.Version(i['version']))
         return manifest, images
 
     def fetch_image_url(self):


### PR DESCRIPTION
distutils.version is deprecated:

    $ python3 -c 'import distutils.version; distutils.version.LooseVersion("1")'
    <string>:1: DeprecationWarning: distutils Version classes are deprecated. Use packaging.version instead.