### PR TITLE
eos-write-installer: Support images without .asc signature; fix finding image partition after repartitioning

### DIFF
--- a/eos-tech-support/eos-write-installer
+++ b/eos-tech-support/eos-write-installer
@@ -21,7 +21,7 @@ if [ ! -f "$EOS_DOWNLOAD_IMAGE" ]; then
     EOS_DOWNLOAD_IMAGE='eos-download-image'
 fi
 
-ARGS=$(getopt -o i:o:luh -l "installer:,os-image:,latest,update-installer,help" -n "$0" -- "$@")
+ARGS=$(getopt -o i:o:luh -l "installer:,os-image:,latest,update-installer,debug,help" -n "$0" -- "$@")
 eval set -- "$ARGS"
 
 usage() {
@@ -38,6 +38,7 @@ Options:
    -o,--os-image  PATH    Path to Endless OS image to add to installer
    -l,--latest            Fetch latest OS and/or eosinstaller image
    -u,--update-installer  Update the installer image when using --latest
+      --debug             Turn on debugging messages
 
 If --latest is specified and --os-image is missing, the newest Endless OS
 image will be downloaded.
@@ -184,6 +185,10 @@ while true; do
         -u|--update-installer)
             shift
             UPDATE_INSTALLER=true
+            ;;
+        --debug)
+            set -x
+            shift
             ;;
         -h|--help)
             usage

--- a/eos-tech-support/eos-write-installer
+++ b/eos-tech-support/eos-write-installer
@@ -50,6 +50,7 @@ EOF
 
 INSTALLER_IMAGE=
 OS_IMAGE=
+OS_IMAGE_SIGNATURE=
 FETCH_LATEST=
 UPDATE_INSTALLER=
 DEVICE=
@@ -63,6 +64,19 @@ EOSIMAGES_WAS_AUTO_MOUNTED=
 function check_exists() {
     if [ ! -f "$1" ]; then
         echo "Error: $1 does not exist or is not a file" >&2
+        exit 1
+    fi
+}
+
+function find_os_image_signature() {
+    local asc="${OS_IMAGE:?}.asc"
+    local sha256="$OS_IMAGE.sha256"
+    if [ -f "$asc" ]; then
+        OS_IMAGE_SIGNATURE="$asc"
+    elif [ -f "$sha256" ]; then
+        OS_IMAGE_SIGNATURE="$sha256"
+    else
+        echo "Error: Neither $asc (GPG signature) nor $sha256 (sha256sum file) exist" >&2
         exit 1
     fi
 }
@@ -133,7 +147,7 @@ function print_device_summary() {
     local eosimages_df
     local other_os_images
     eosimages_df=$(df -h . | tail -1 | tr -s ' ' | cut -d ' ' -f4)
-    other_os_images=$(find . -type f -not -name '*.asc')
+    other_os_images=$(find . -type f -not '(' -name '*.asc' -o -name '*.sha256' ')' )
     echo "$DEVICE has $eosimages_df remaining and contains the following OS images:" >&2
     while read -r other_os_image; do
         local other_os_image_name
@@ -160,7 +174,7 @@ while true; do
             shift
             OS_IMAGE="$1"
             check_exists "$OS_IMAGE"
-            check_exists "$OS_IMAGE.asc"
+            find_os_image_signature
             shift
             ;;
         -l|--latest)
@@ -244,6 +258,7 @@ if [ -n "$FETCH_LATEST" ]; then
 
     if [ -z "$OS_IMAGE" ]; then
         OS_IMAGE=$($EOS_DOWNLOAD_IMAGE --product eos)
+        find_os_image_signature
     fi
 fi
 
@@ -338,7 +353,7 @@ if [ -f "$OS_IMAGE" ]; then
     echo "Adding $OS_IMAGE to eosimages on $DEVICE..." >&2
 
     # Write image and its signature
-    cp "$OS_IMAGE.asc" "$EOSIMAGES_MOUNTPOINT"/
+    cp "$OS_IMAGE_SIGNATURE" "$EOSIMAGES_MOUNTPOINT"/
     pv "$OS_IMAGE" > "$EOSIMAGES_MOUNTPOINT"/"$(basename "$OS_IMAGE")"
 fi
 

--- a/eos-tech-support/eos-write-installer
+++ b/eos-tech-support/eos-write-installer
@@ -315,9 +315,13 @@ if [ -f "$INSTALLER_IMAGE" ]; then
 
     # At this point udev should have seen that sfdisk closed the block device
     # which was opened for writing, so it will be reprobing.
-    # Add udevadm settle here to avoid races.
+    # Add udevadm settle here to avoid racing with udev deleting and recreating
+    # the block device
     udevadm settle
+    # Now inform the kernel that the partition table has changed, and wait for
+    # it and udev to finish digesting that.
     sudo partprobe "$DEVICE"
+    udevadm settle
 
     # Grab the eosimages partition and create exfat fs on it
     update_eosimages_part


### PR DESCRIPTION
For 3 years eos-installer has supported installing images that do not have an `.asc` detached GPG signature, only a `.sha256` file containing a SHA256 digest of the image. This is to allow installing images built by third parties, who do not have access to our image signing key.

However, `eos-write-installer` has continued to insist on the `.asc` file being present.

Fix this; and fix a recently-introduced regression.

https://phabricator.endlessm.com/T35362