### PR TITLE
core: Add wireguard-tools to OS

### DIFF
--- a/eos-core-depends
+++ b/eos-core-depends
@@ -228,6 +228,7 @@ usbmuxd
 vainfo
 whiptail
 wget
+wireguard-tools
 xinput
 # Assuming useful for Orca screen reader
 xbrlapi


### PR DESCRIPTION
This is all that is needed to configure a Wireguard VPN from the CLI: we
already ship the kernel module.

This was requested on our forum
<https://community.endlessos.com/t/wireguard-support/22663>. While there
are workarounds for us not shipping this package, we may as well add it:
it is just a few hundred kilobytes.

https://phabricator.endlessm.com/T35393
