### PR TITLE
eos-diagnostics: Remove pw-dump output

### DIFF
--- a/eos-tech-support/eos-diagnostics
+++ b/eos-tech-support/eos-diagnostics
@@ -585,8 +585,7 @@ let diagnostics = [
         hardwareInfo: true,
         content: function() {
             return trySpawn('wpctl status') + '\n' +
-                   trySpawn('pw-cli info all') + '\n' +
-                   trySpawn('pw-dump');
+                   trySpawn('pw-cli info all')
         },
     },
     {


### PR DESCRIPTION
This partially reverts b6cb358cad2af72fd6e2bb29b5be9d4f692fd21d
(“eos-diagnostics: Add PipeWire information”).

On my system, this produces 10,221 lines of JSON. This is almost a
quarter of the full diagnostic file at 42,697 lines, of which 24,000
lines is the journal.

I for one have never found this output useful, and in fact it is really
annoying to have to scroll past to get down to the journal. It lists all
the pipewire modules we ship (redundant, we know what they are) and all
the interesting information about devices & clients is in the `pw-cli
info all` output.
