### PR TITLE
Adapt scripts for lack of /var/cache/debconf

### DIFF
--- a/eos-tech-support/eos-dev-unlock
+++ b/eos-tech-support/eos-dev-unlock
@@ -42,9 +42,3 @@ systemctl stop eos-autoupdater.service
 systemctl stop eos-updater.service
 
 ostree admin unlock "$@"
-
-# Some tweaks to make apt work
-if [ ! -d /var/cache/debconf ]; then
-  OSTREE_DEPLOY_CURRENT=$(ostree admin --print-current-dir)
-  cp -a $OSTREE_DEPLOY_CURRENT/var/cache/debconf /var/cache/
-fi

--- a/eos-tech-support/eos-diagnostics
+++ b/eos-tech-support/eos-diagnostics
@@ -435,20 +435,6 @@ function collectTemperatureInfo() {
     }
 }
 
-function collectEosDevInfo() {
-    let output = '';
-    let signalDir = Gio.File.new_for_path('/var/cache/debconf');
-    if (signalDir.query_exists(null)) {
-        output += '***************************************************************\n';
-        output += '*                           WARNING                           *\n';
-        output += '* eos-dev-unlock or eos-convert-system was run on the system! *\n';
-        output += '***************************************************************\n';
-        output += '\n';
-    }
-
-    return output;
-}
-
 function isCoredumpdEnabled() {
     let pattern = tryReadFile('/proc/sys/kernel/core_pattern', '');
     return (pattern.indexOf('systemd-coredump') >= 0);
@@ -801,8 +787,6 @@ let diagnostics = [
 
 function dumpDiagnostics(filename, verboseFlag, fullJournalFlag) {
     let fullDump = '';
-
-    fullDump += collectEosDevInfo();
 
     diagnostics.forEach(function(diag) {
         let content = diag.content(verboseFlag, fullJournalFlag);


### PR DESCRIPTION
Since https://github.com/endlessm/eos-ostree-builder/commit/1bda62eeaecb4a34dbdd7eef78afebd879076054 we have completely wiped /var in the ostree:

> Anything in `/var` is wasted space in the commit since it will mounted over at runtime. OSTree's deploy code has been warning about this for years and it may eventually become a hard failure.

Adjust `eos-dev-unlock` to not try to populate /var/cache/debconf from the ostree deployment; and adjust `eos-diagnostics` to stop using the presence of `/var/cache/debconf` to detect that `eos-dev-unlock` has been run.
