### PR TITLE
Install pipewire's libcamera modules

### DIFF
--- a/base-depends
+++ b/base-depends
@@ -29,6 +29,7 @@ libglx-mesa0
 libnss-altfiles
 libnss-myhostname
 libspa-0.2-bluetooth
+libspa-0.2-libcamera
 locales-all
 lzma
 mawk


### PR DESCRIPTION
This allows accessing webcams through Pipewire, which is the way of the
future for applications to stop needing a --devices=all sandbox hole.

https://phabricator.endlessm.com/T35327
