### PR TITLE
os: Add mokutil on amd64 for secure boot management

### DIFF
--- a/os-depends
+++ b/os-depends
@@ -85,6 +85,7 @@ mesa-utils
 mesa-utils-extra
 mesa-vulkan-drivers
 mobile-broadband-provider-info
+mokutil [amd64]
 mtr-tiny
 nano
 net-tools


### PR DESCRIPTION
This utility has many convenient features for interacting with secure boot UEFI variables. In addition to managing the MOK state from userspace, it can:

* Show the current SecureBoot state
* Set the UEFI variables to enable verbosity in shim and fallback
* Show and set the current SBAT policy
* Dump out all the standard SecureBoot databases (PK, KEK, DB, DBX) in standard PEM format.

On debian you get this automatically as a dependency of shim-signed, but we use a different package for our signed shim programs.

https://phabricator.endlessm.com/T34488