### PR TITLE
eos-write-installer: Run udevadm settle as root

### DIFF
--- a/eos-tech-support/eos-write-installer
+++ b/eos-tech-support/eos-write-installer
@@ -317,21 +317,25 @@ if [ -f "$INSTALLER_IMAGE" ]; then
     # which was opened for writing, so it will be reprobing.
     # Add udevadm settle here to avoid racing with udev deleting and recreating
     # the block device
-    udevadm settle
+    sudo udevadm settle
     # Now inform the kernel that the partition table has changed, and wait for
     # it and udev to finish digesting that.
     sudo partprobe "$DEVICE"
-    udevadm settle
+    sudo udevadm settle
 
     # Grab the eosimages partition and create exfat fs on it
     update_eosimages_part
     if [ -n "$EOSIMAGES_PART" ]; then
         sudo mkfs.exfat -n eosimages "$EOSIMAGES_PART"
+    else
+        echo "Error: Newly-created eosimages partition not found" >&2
+        exit 1
+
     fi
 
     # Give udisks a chance to notice the new partition
     sudo partprobe "$DEVICE"
-    udevadm settle
+    sudo udevadm settle
 fi
 
 if [ ! -b "$EOSIMAGES_PART" ]; then


### PR DESCRIPTION
Prior to commit ce670ad61b169bcf403b641e0b55a3e3139efb36, this script
could only be run as root. That commit allowed it to run as a regular
user, wrapping commands that need root with sudo.

In my local usage I found that the script would reliably fail after
writing eosinstaller to disk and adding an eosimages partition.
update_eosimages_part would not find any partition with the 'eosimages'
label; so EOSIMAGES_PART would be the empty string; so mkfs.exfat would
not be run; and then the check below this block would fail:

    /dev/sdb has no eosimages partition... aborting!

On closer inspection, while `udevadm settle` can be successfully run as
an unprivileged user, it actually does something slightly different
depending on whether it is run as root or not:

- If invoked as root, it first pings the daemon, waits for a reply, and
  only then waits for the queue to be empty.
- Otherwise, it checks that the control socket exists (indicating that
  udevd is running) but does not send any command; it just waits for the
  queue to be empty.

(Digging a little deeper, "empty" means /run/udev/queue doesn't exist.)

In my testing, the additional round-trip of pinging the udev daemon
reliably fixes the script.

A more perfect fix would be to wait (up to a timeout) for the new
partition to appear, rather than relying on a delicate sequence of
udevadm settle/partprobe invocations.

https://github.com/endlessm/systemd/blob/2296e3cb369155394ff083b0ecb8f389639bc677/src/udev/udevadm-settle.c#L200-L224

https://phabricator.endlessm.com/T35619
