### PR TITLE
os: Install linux-image-generic or linux-rpi on arm64 platforms

### DIFF
--- a/os-depends
+++ b/os-depends
@@ -76,7 +76,7 @@ linux-firmware
 # use the linux-signed-image variant, which contains the kernel
 # signed for UEFI.
 linux-signed-image-generic [amd64]
-linux-image-generic [arm64]
+linux-image-generic [arm64] | linux-rpi [arm64]
 low-memory-monitor
 lsb-base
 lsb-release


### PR DESCRIPTION
Going to have a new OSTree branch for RPi device. And, the OSTree branch installs linux-rpi for having better hardware support on RPi devices. So, install either linux-image-generic, or linux-rpi on arm64 platforms. The OSTree build configuration decides installing which linux kernel.

https://app.asana.com/1/1203676861188277/project/1211061530470838/task/1211622697341771