### PR TITLE
 Introduce eos-core-rpi package for RPi devices

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -42,7 +42,6 @@ Description: Target packages of the Endless distribution for amd64
 Package: eos-core-arm64
 Architecture: arm64
 Depends: ${misc:Depends}, ${eos:Depends}
-Provides: eos-core-rpi3
 Description: Target packages of the Endless distribution for arm64
  This package depends on all packages required for the Endless OS core images
  .
@@ -63,6 +62,18 @@ Description: Target packages of the Endless distribution for amd64 nexthw
  This set provides the platform specific package list for amd64 nexthw
  builds. These builds provide newer hardware enablement on top of the
  standard amd64 builds.
+
+Package: eos-core-rpi
+Architecture: arm64
+Depends: ${misc:Depends}, ${eos:Depends}
+Description: Target packages of the Endless distribution for RPi devices
+ This package depends on all packages required for the Endless OS core images
+ .
+ It is also used to help ensure proper upgrades, so it is recommended that
+ it not be removed.
+ .
+ This set provides the platform specific package list for RPi devices.
+
 
 Package: eos-installer-meta
 Architecture: any

--- a/eos-core-arm64-depends
+++ b/eos-core-arm64-depends
@@ -1,5 +1,5 @@
 eos-core
-u-boot-rpi
+linux-image-generic
 u-boot-amlogic
 u-boot-rockchip
 xserver-xorg-legacy

--- a/eos-core-rpi-depends
+++ b/eos-core-rpi-depends
@@ -1,0 +1,4 @@
+eos-core
+linux-rpi
+u-boot-rpi
+xserver-xorg-legacy

--- a/os-depends
+++ b/os-depends
@@ -76,7 +76,6 @@ linux-firmware
 # use the linux-signed-image variant, which contains the kernel
 # signed for UEFI.
 linux-signed-image-generic [amd64]
-linux-image-generic [arm64]
 low-memory-monitor
 lsb-base
 lsb-release


### PR DESCRIPTION
Going to have a new OSTree branch for RPi device. And, the OSTree branch installs the new introduced eos-core-rpi package depending on linux-rpi for having better hardware support on RPi devices.

So, move dependency linux-image-generic package from os-depends to eos-core-arm64-depends. And, add linux-rpi to eos-core-rpi-depends. Besides, tweak the u-boot dependencies at the same time.

https://app.asana.com/1/1203676861188277/project/1211061530470838/task/1211622697341771