### PR TITLE
os-depends: Add firmware-nvidia-gsp

### DIFF
--- a/os-depends
+++ b/os-depends
@@ -29,6 +29,7 @@ eos-version-number
 exfatprogs
 fdisk
 file
+firmware-nvidia-gsp [amd64]
 firmware-sof-signed
 fonts-dejavu
 fscrypt


### PR DESCRIPTION
The new nvidia-graphics-drivers 555.58.02-2 will load the firmware file provided by firmware-nvidia-gsp:
```
nvidia 0000:01:00.0: Direct firmware load for nvidia/555.58.02/gsp_tu10x.bin failed with error -2
```
So, add firmware-nvidia-gsp into amd64 platform's dependency.

https://app.asana.com/1/1203676861188277/project/1211949321657103/task/1212760656967807