### PR TITLE
eos-toolbox-dev-depends: Add eos-payg-admin

### DIFF
--- a/eos-toolbox-dev-depends
+++ b/eos-toolbox-dev-depends
@@ -27,6 +27,7 @@ debootstrap
 devscripts
 diffutils
 endless-ca-cert
+eos-payg-admin
 findutils
 flatpak-xdg-utils
 gdb


### PR DESCRIPTION
Install eos-payg-admin to have the utility eos-gen-paygid to generate more PAYG IDs & Keys.

https://app.asana.com/1/1203676861188277/project/1211949321657103/task/1213224911599528